### PR TITLE
feat: enhance db operations for prisma metadata store

### DIFF
--- a/backend/modules/metadata_store/base.py
+++ b/backend/modules/metadata_store/base.py
@@ -45,15 +45,6 @@ class BaseMetadataStore(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def aget_retrieve_collection_by_name(
-        self, collection_name: str, no_cache: bool = True
-    ) -> Optional[Collection]:
-        """
-        Get a collection from the metadata store by name used during retrieval phase
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
     async def aget_collections(
         self,
     ) -> List[Collection]:
@@ -104,7 +95,7 @@ class BaseMetadataStore(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    async def aassociate_data_source_with_collection(
+    async def aassociate_data_sources_with_collection(
         self,
         collection_name: str,
         data_source_association: AssociateDataSourceWithCollection,

--- a/backend/modules/query_controllers/base.py
+++ b/backend/modules/query_controllers/base.py
@@ -62,7 +62,7 @@ class BaseQueryController:
         Get the vector store for the collection
         """
         client = await get_client()
-        collection = await client.aget_retrieve_collection_by_name(collection_name)
+        collection = await client.aget_collection_by_name(collection_name)
         if collection is None:
             raise HTTPException(status_code=404, detail="Collection not found")
 

--- a/backend/modules/vector_db/weaviate.py
+++ b/backend/modules/vector_db/weaviate.py
@@ -6,6 +6,7 @@ from langchain_community.vectorstores.weaviate import Weaviate
 from langchain_core.documents import Document
 
 from backend.constants import DATA_POINT_FQN_METADATA_KEY
+from backend.logger import logger
 from backend.modules.vector_db.base import BaseVectorDB
 from backend.types import DataPointVector, VectorDBConfig
 
@@ -125,7 +126,7 @@ class WeaviateVectorDB(BaseVectorDB):
         )
         deleted_vectors = res.get("results", {}).get("successful", None)
         if deleted_vectors:
-            print(f"Deleted {len(document_ids)} documents from the collection")
+            logger.info(f"Deleted {len(document_ids)} documents from the collection")
 
     def get_vector_client(self):
         return self.weaviate_client

--- a/backend/server/app.py
+++ b/backend/server/app.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from fastapi import APIRouter, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from prisma.errors import RecordNotFoundError, UniqueViolationError
 
 from backend.logger import logger
 from backend.modules.query_controllers.query_controller import QUERY_CONTROLLER_REGISTRY
@@ -74,6 +75,22 @@ async def catch_exceptions_middleware(_request: Request, exc: Exception):
     logger.exception(exc)
     return JSONResponse(
         content={"error": f"An unexpected error occurred: {str(exc)}"}, status_code=500
+    )
+
+
+@app.exception_handler(RecordNotFoundError)
+async def catch_exceptions_middleware(_request: Request, exc: RecordNotFoundError):
+    logger.exception(exc)
+    return JSONResponse(
+        content={"error": f"Record not found: {str(exc)}"}, status_code=404
+    )
+
+
+@app.exception_handler(UniqueViolationError)
+async def catch_exceptions_middleware(_request: Request, exc: UniqueViolationError):
+    logger.exception(exc)
+    return JSONResponse(
+        content={"error": f"Record already exists: {str(exc)}"}, status_code=400
     )
 
 

--- a/backend/server/app.py
+++ b/backend/server/app.py
@@ -2,7 +2,7 @@ import asyncio
 import multiprocessing as mp
 from contextlib import asynccontextmanager
 
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
@@ -67,6 +67,14 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.exception_handler(Exception)
+async def catch_exceptions_middleware(_request: Request, exc: Exception):
+    logger.exception(exc)
+    return JSONResponse(
+        content={"error": f"An unexpected error occurred: {str(exc)}"}, status_code=500
+    )
 
 
 @app.get("/health-check")

--- a/backend/server/routers/collection.py
+++ b/backend/server/routers/collection.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, HTTPException, Path, Request
+from fastapi import APIRouter, Depends, HTTPException, Path, Request
 from fastapi.responses import JSONResponse
 
 from backend.indexer.indexer import ingest_data as ingest_data_to_collection
 from backend.logger import logger
+from backend.modules.metadata_store.base import BaseMetadataStore
 from backend.modules.metadata_store.client import get_client
 from backend.modules.model_gateway.model_gateway import model_gateway
 from backend.modules.vector_db.client import VECTOR_STORE_CLIENT
@@ -50,10 +51,12 @@ async def get_collection_by_name(collection_name: str = Path(title="Collection n
 
 
 @router.post("")
-async def create_collection(collection: CreateCollectionDto):
+async def create_collection(
+    collection: CreateCollectionDto,
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
+):
     """API to create a collection"""
     logger.info(f"Creating collection {collection.name}...")
-    metadata_store_client = await get_client()
     created_collection = await metadata_store_client.acreate_collection(
         collection=CreateCollection(
             name=collection.name,
@@ -62,11 +65,6 @@ async def create_collection(collection: CreateCollectionDto):
         )
     )
     logger.info(f"Creating collection {collection.name} on vector db...")
-    print("collection.embedder_config.name", collection.embedder_config.name)
-    print(
-        "model_gateway.get_embedder_from_model_config(collection.embedder_config.name)",
-        model_gateway.get_embedder_from_model_config(collection.embedder_config.name),
-    )
     VECTOR_STORE_CLIENT.create_collection(
         collection_name=collection.name,
         embeddings=model_gateway.get_embedder_from_model_config(
@@ -99,9 +97,9 @@ async def create_collection(collection: CreateCollectionDto):
 @router.post("/associate_data_source")
 async def associate_data_source_to_collection(
     request: AssociateDataSourceWithCollectionDto,
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
 ):
     """Add a data source to the collection"""
-    metadata_store_client = await get_client()
     collection = await metadata_store_client.aassociate_data_sources_with_collection(
         collection_name=request.collection_name,
         data_source_associations=[
@@ -117,9 +115,9 @@ async def associate_data_source_to_collection(
 @router.post("/unassociate_data_source")
 async def unassociate_data_source_from_collection(
     request: UnassociateDataSourceWithCollectionDto,
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
 ):
     """Remove a data source to the collection"""
-    metadata_store_client = await get_client()
     collection = await metadata_store_client.aunassociate_data_source_with_collection(
         collection_name=request.collection_name,
         data_source_fqn=request.data_source_fqn,
@@ -142,17 +140,21 @@ async def ingest_data(
 
 
 @router.delete("/{collection_name}")
-async def delete_collection(collection_name: str = Path(title="Collection name")):
+async def delete_collection(
+    collection_name: str = Path(title="Collection name"),
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
+):
     """Delete collection given its name"""
-    metadata_store_client = await get_client()
     await metadata_store_client.adelete_collection(collection_name, include_runs=True)
     VECTOR_STORE_CLIENT.delete_collection(collection_name=collection_name)
     return JSONResponse(content={"deleted": True})
 
 
 @router.post("/data_ingestion_runs/list")
-async def list_data_ingestion_runs(request: ListDataIngestionRunsDto):
-    metadata_store_client = await get_client()
+async def list_data_ingestion_runs(
+    request: ListDataIngestionRunsDto,
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
+):
     data_ingestion_runs = await metadata_store_client.aget_data_ingestion_runs(
         request.collection_name, request.data_source_fqn
     )
@@ -166,9 +168,9 @@ async def list_data_ingestion_runs(request: ListDataIngestionRunsDto):
 @router.get("/data_ingestion_runs/{data_ingestion_run_name}/status")
 async def get_collection_status(
     data_ingestion_run_name: str = Path(title="Data Ingestion Run name"),
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
 ):
     """Get status for given data ingestion run"""
-    metadata_store_client = await get_client()
     data_ingestion_run = await metadata_store_client.aget_data_ingestion_run(
         data_ingestion_run_name=data_ingestion_run_name, no_cache=True
     )

--- a/backend/server/routers/collection.py
+++ b/backend/server/routers/collection.py
@@ -22,89 +22,78 @@ router = APIRouter(prefix="/v1/collections", tags=["collections"])
 @router.get("")
 async def get_collections():
     """API to list all collections with details"""
-    try:
-        logger.debug("Listing all the collections...")
-        client = await get_client()
-        collections = await client.aget_collections()
-        if collections is None:
-            return JSONResponse(content={"collections": []})
-        return JSONResponse(
-            content={"collections": [obj.model_dump() for obj in collections]}
-        )
-    except Exception as exp:
-        logger.exception("Failed to get collection")
-        raise HTTPException(status_code=500, detail=str(exp))
+    logger.debug("Listing all the collections...")
+    metadata_store_client = await get_client()
+    collections = await metadata_store_client.aget_collections()
+    if collections is None:
+        return JSONResponse(content={"collections": []})
+    return JSONResponse(
+        content={"collections": [obj.model_dump() for obj in collections]}
+    )
 
 
 @router.get("/list")
 async def list_collections():
-    try:
-        client = await get_client()
-        collections = await client.alist_collections()
-        return JSONResponse(content={"collections": collections})
-    except Exception as exp:
-        logger.exception("Failed to list collections")
-        raise HTTPException(status_code=500, detail=str(exp))
+    metadata_store_client = await get_client()
+    collections = await metadata_store_client.alist_collections()
+    return JSONResponse(content={"collections": collections})
 
 
 @router.get("/{collection_name}")
 async def get_collection_by_name(collection_name: str = Path(title="Collection name")):
     """Get the collection config given its name"""
-    try:
-        client = await get_client()
-        collection = await client.aget_collection_by_name(collection_name)
-        if collection is None:
-            return JSONResponse(content={"collection": []})
-        return JSONResponse(content={"collection": collection.model_dump()})
-    except HTTPException as exp:
-        raise exp
-    except Exception as exp:
-        logger.exception("Failed to get collection by name")
-        raise HTTPException(status_code=500, detail=str(exp))
+    metadata_store_client = await get_client()
+    collection = await metadata_store_client.aget_collection_by_name(collection_name)
+    if collection is None:
+        return JSONResponse(content={"collection": []})
+    return JSONResponse(content={"collection": collection.model_dump()})
 
 
 @router.post("")
 async def create_collection(collection: CreateCollectionDto):
     """API to create a collection"""
-    try:
-        logger.info(f"Creating collection {collection.name}...")
-        client = await get_client()
-        created_collection = await client.acreate_collection(
-            collection=CreateCollection(
-                name=collection.name,
-                description=collection.description,
-                embedder_config=collection.embedder_config,
-            )
+    logger.info(f"Creating collection {collection.name}...")
+    metadata_store_client = await get_client()
+    created_collection = await metadata_store_client.acreate_collection(
+        collection=CreateCollection(
+            name=collection.name,
+            description=collection.description,
+            embedder_config=collection.embedder_config,
         )
-        logger.info(f"Creating collection {collection.name} on vector db...")
-        VECTOR_STORE_CLIENT.create_collection(
-            collection_name=collection.name,
-            embeddings=model_gateway.get_embedder_from_model_config(
-                model_name=collection.embedder_config.name
-            ),
-        )
-        logger.info(f"Created collection... {created_collection}")
+    )
+    logger.info(f"Creating collection {collection.name} on vector db...")
+    print("collection.embedder_config.name", collection.embedder_config.name)
+    print(
+        "model_gateway.get_embedder_from_model_config(collection.embedder_config.name)",
+        model_gateway.get_embedder_from_model_config(collection.embedder_config.name),
+    )
+    VECTOR_STORE_CLIENT.create_collection(
+        collection_name=collection.name,
+        embeddings=model_gateway.get_embedder_from_model_config(
+            model_name=collection.embedder_config.name
+        ),
+    )
+    logger.info(f"Created collection... {created_collection}")
 
-        if collection.associated_data_sources:
-            for data_source in collection.associated_data_sources:
-                await client.aassociate_data_source_with_collection(
-                    collection_name=created_collection.name,
-                    data_source_association=AssociateDataSourceWithCollection(
-                        data_source_fqn=data_source.data_source_fqn,
-                        parser_config=data_source.parser_config,
-                    ),
-                )
-            created_collection = await client.aget_collection_by_name(
-                collection_name=created_collection.name
+    if collection.associated_data_sources:
+        data_source_associations = [
+            AssociateDataSourceWithCollection(
+                data_source_fqn=data_source.data_source_fqn,
+                parser_config=data_source.parser_config,
             )
-        return JSONResponse(
-            content={"collection": created_collection.model_dump()}, status_code=201
+            for data_source in collection.associated_data_sources
+        ]
+
+        created_collection = (
+            await metadata_store_client.aassociate_data_sources_with_collection(
+                collection_name=created_collection.name,
+                data_source_associations=data_source_associations,
+            )
         )
-    except HTTPException as exp:
-        raise exp
-    except Exception as exp:
-        logger.exception(f"Failed to create collection")
-        raise HTTPException(status_code=500, detail=str(exp))
+
+    return JSONResponse(
+        content={"collection": created_collection.model_dump()}, status_code=201
+    )
 
 
 @router.post("/associate_data_source")
@@ -112,21 +101,17 @@ async def associate_data_source_to_collection(
     request: AssociateDataSourceWithCollectionDto,
 ):
     """Add a data source to the collection"""
-    try:
-        client = await get_client()
-        collection = await client.aassociate_data_source_with_collection(
-            collection_name=request.collection_name,
-            data_source_association=AssociateDataSourceWithCollection(
+    metadata_store_client = await get_client()
+    collection = await metadata_store_client.aassociate_data_sources_with_collection(
+        collection_name=request.collection_name,
+        data_source_associations=[
+            AssociateDataSourceWithCollection(
                 data_source_fqn=request.data_source_fqn,
                 parser_config=request.parser_config,
-            ),
-        )
-        return JSONResponse(content={"collection": collection.model_dump()})
-    except HTTPException as exp:
-        raise exp
-    except Exception as exp:
-        logger.exception("Failed to associate data source")
-        raise HTTPException(status_code=500, detail=str(exp))
+            )
+        ],
+    )
+    return JSONResponse(content={"collection": collection.model_dump()})
 
 
 @router.post("/unassociate_data_source")
@@ -134,18 +119,12 @@ async def unassociate_data_source_from_collection(
     request: UnassociateDataSourceWithCollectionDto,
 ):
     """Remove a data source to the collection"""
-    try:
-        client = await get_client()
-        collection = await client.aunassociate_data_source_with_collection(
-            collection_name=request.collection_name,
-            data_source_fqn=request.data_source_fqn,
-        )
-        return JSONResponse(content={"collection": collection.model_dump()})
-    except HTTPException as exp:
-        raise exp
-    except Exception as exp:
-        logger.exception("Failed to unassociate data source from collection")
-        raise HTTPException(status_code=500, detail=str(exp))
+    metadata_store_client = await get_client()
+    collection = await metadata_store_client.aunassociate_data_source_with_collection(
+        collection_name=request.collection_name,
+        data_source_fqn=request.data_source_fqn,
+    )
+    return JSONResponse(content={"collection": collection.model_dump()})
 
 
 @router.post("/ingest")
@@ -157,36 +136,24 @@ async def ingest_data(
         process_pool = request.app.state.process_pool
     except AttributeError:
         process_pool = None
-    try:
-        return await ingest_data_to_collection(
-            ingest_data_to_collection_dto, pool=process_pool
-        )
-    except HTTPException as exp:
-        raise exp
-    except Exception as exp:
-        logger.exception("Failed to ingest data")
-        raise HTTPException(status_code=500, detail=str(exp))
+    return await ingest_data_to_collection(
+        ingest_data_to_collection_dto, pool=process_pool
+    )
 
 
 @router.delete("/{collection_name}")
 async def delete_collection(collection_name: str = Path(title="Collection name")):
     """Delete collection given its name"""
-    try:
-        client = await get_client()
-        await client.adelete_collection(collection_name, include_runs=True)
-        VECTOR_STORE_CLIENT.delete_collection(collection_name=collection_name)
-        return JSONResponse(content={"deleted": True})
-    except HTTPException as exp:
-        raise exp
-    except Exception as exp:
-        logger.exception("Failed to delete collection")
-        raise HTTPException(status_code=500, detail=str(exp))
+    metadata_store_client = await get_client()
+    await metadata_store_client.adelete_collection(collection_name, include_runs=True)
+    VECTOR_STORE_CLIENT.delete_collection(collection_name=collection_name)
+    return JSONResponse(content={"deleted": True})
 
 
 @router.post("/data_ingestion_runs/list")
 async def list_data_ingestion_runs(request: ListDataIngestionRunsDto):
-    client = await get_client()
-    data_ingestion_runs = await client.aget_data_ingestion_runs(
+    metadata_store_client = await get_client()
+    data_ingestion_runs = await metadata_store_client.aget_data_ingestion_runs(
         request.collection_name, request.data_source_fqn
     )
     return JSONResponse(
@@ -201,8 +168,8 @@ async def get_collection_status(
     data_ingestion_run_name: str = Path(title="Data Ingestion Run name"),
 ):
     """Get status for given data ingestion run"""
-    client = await get_client()
-    data_ingestion_run = await client.aget_data_ingestion_run(
+    metadata_store_client = await get_client()
+    data_ingestion_run = await metadata_store_client.aget_data_ingestion_run(
         data_ingestion_run_name=data_ingestion_run_name, no_cache=True
     )
     if data_ingestion_run is None:

--- a/backend/server/routers/components.py
+++ b/backend/server/routers/components.py
@@ -10,19 +10,16 @@ router = APIRouter(prefix="/v1/components", tags=["components"])
 @router.get("/parsers")
 def get_parsers():
     """Get available parsers from the registered parsers"""
-    parsers = list_parsers()
-    return parsers
+    return list_parsers()
 
 
 @router.get("/dataloaders")
 def get_dataloaders():
     """Get available data loaders from registered data loaders"""
-    data_loaders = list_dataloaders()
-    return data_loaders
+    return list_dataloaders()
 
 
 @router.get("/query_controllers")
 def get_query_controllers():
     """Get available query controllers from registered query controllers"""
-    query_controllers = list_query_controllers()
-    return query_controllers
+    return list_query_controllers()

--- a/backend/server/routers/data_source.py
+++ b/backend/server/routers/data_source.py
@@ -73,13 +73,15 @@ async def delete_data_source(
             shutil.rmtree(folder_path)
             logger.info(f"Deleted folder: {folder_path}")
 
-    if deleted_data_source.type == "truefoundry":
+    if "truefoundry" in deleted_data_source.fqn:
         # Delete the data directory from truefoundry data directory
         try:
-            # Since the uri contains the source of data
+            # When the data source is of type `truefoundry`, the uri contains the fqn of the data directory
+            # Fetch the data directory object
             data_directory = TRUEFOUNDRY_CLIENT.get_data_directory_by_fqn(
-                data_source_uri
+                deleted_data_source.uri
             )
+            # Delete the data directory
             data_directory.delete(delete_contents=True)
             logger.info(f"Deleted data directory: {data_directory}")
         except Exception as e:

--- a/backend/server/routers/data_source.py
+++ b/backend/server/routers/data_source.py
@@ -17,10 +17,9 @@ router = APIRouter(prefix="/v1/data_source", tags=["data_source"])
 
 
 @router.get("")
-async def get_data_source(
-    metadata_store_client: BaseMetadataStore = Depends(get_client),
-):
+async def get_data_source():
     """Get data sources"""
+    metadata_store_client: BaseMetadataStore = await get_client()
     data_sources = await metadata_store_client.aget_data_sources()
     return JSONResponse(
         content={"data_sources": [obj.model_dump() for obj in data_sources]}
@@ -28,20 +27,17 @@ async def get_data_source(
 
 
 @router.get("/list")
-async def list_data_sources(
-    metadata_store_client: BaseMetadataStore = Depends(get_client),
-):
+async def list_data_sources():
     """Get data sources"""
+    metadata_store_client: BaseMetadataStore = await get_client()
     data_sources = await metadata_store_client.alist_data_sources()
     return JSONResponse(content={"data_sources": data_sources})
 
 
 @router.post("")
-async def add_data_source(
-    data_source: CreateDataSource,
-    metadata_store_client: BaseMetadataStore = Depends(get_client),
-):
+async def add_data_source(data_source: CreateDataSource):
     """Create a data source for the given collection"""
+    metadata_store_client: BaseMetadataStore = await get_client()
     created_data_source = await metadata_store_client.acreate_data_source(
         data_source=data_source
     )
@@ -53,9 +49,9 @@ async def add_data_source(
 @router.delete("/delete")
 async def delete_data_source(
     data_source_fqn: str,
-    metadata_store_client: BaseMetadataStore = Depends(get_client),
 ):
     """Delete a data source"""
+    metadata_store_client: BaseMetadataStore = await get_client()
     deleted_data_source = await metadata_store_client.adelete_data_source(
         unquote(data_source_fqn)
     )

--- a/backend/server/routers/data_source.py
+++ b/backend/server/routers/data_source.py
@@ -1,21 +1,26 @@
+import os
+import shutil
 from contextlib import asynccontextmanager
 from urllib.parse import unquote
 
-from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 
 from backend.logger import logger
 from backend.modules.metadata_store.base import BaseMetadataStore
 from backend.modules.metadata_store.client import get_client
+from backend.settings import settings
 from backend.types import CreateDataSource
+from backend.utils import TRUEFOUNDRY_CLIENT
 
 router = APIRouter(prefix="/v1/data_source", tags=["data_source"])
 
 
 @router.get("")
-async def get_data_source():
+async def get_data_source(
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
+):
     """Get data sources"""
-    metadata_store_client = await get_client()
     data_sources = await metadata_store_client.aget_data_sources()
     return JSONResponse(
         content={"data_sources": [obj.model_dump() for obj in data_sources]}
@@ -23,9 +28,10 @@ async def get_data_source():
 
 
 @router.get("/list")
-async def list_data_sources():
+async def list_data_sources(
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
+):
     """Get data sources"""
-    metadata_store_client = await get_client()
     data_sources = await metadata_store_client.alist_data_sources()
     return JSONResponse(content={"data_sources": data_sources})
 
@@ -33,9 +39,9 @@ async def list_data_sources():
 @router.post("")
 async def add_data_source(
     data_source: CreateDataSource,
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
 ):
     """Create a data source for the given collection"""
-    metadata_store_client = await get_client()
     created_data_source = await metadata_store_client.acreate_data_source(
         data_source=data_source
     )
@@ -45,8 +51,42 @@ async def add_data_source(
 
 
 @router.delete("/delete")
-async def delete_data_source(data_source_fqn: str):
+async def delete_data_source(
+    data_source_fqn: str,
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
+):
     """Delete a data source"""
-    metadata_store_client = await get_client()
-    await metadata_store_client.adelete_data_source(unquote(data_source_fqn))
+    deleted_data_source = await metadata_store_client.adelete_data_source(
+        unquote(data_source_fqn)
+    )
+
+    # Upon successful deletion of the data source, delete the data from `/users_data` directory if data source is of type `localdir`
+    if deleted_data_source.type == "localdir":
+        data_source_uri = deleted_data_source.uri
+        # data_source_uri is of the form: `/app/users_data/folder_name`
+        folder_name = data_source_uri.split("/")[-1]
+        folder_path = os.path.join(settings.LOCAL_DATA_DIRECTORY, folder_name)
+        logger.info(
+            f"Deleting folder: {folder_path}, path exists: {os.path.exists(folder_path)}"
+        )
+        # If the folder does not exist, skip deleting it
+        if not os.path.exists(folder_path):
+            logger.error(f"Folder does not exist: {folder_path}")
+        else:
+            # Delete the folder
+            shutil.rmtree(folder_path)
+            logger.info(f"Deleted folder: {folder_path}")
+
+    if deleted_data_source.type == "truefoundry":
+        # Delete the data directory from truefoundry data directory
+        try:
+            # Since the uri contains the source of data
+            data_directory = TRUEFOUNDRY_CLIENT.get_data_directory_by_fqn(
+                data_source_uri
+            )
+            data_directory.delete(delete_contents=True)
+            logger.info(f"Deleted data directory: {data_directory}")
+        except Exception as e:
+            logger.exception(f"Failed to delete data directory: {e}")
+
     return JSONResponse(content={"deleted": True})

--- a/backend/server/routers/rag_apps.py
+++ b/backend/server/routers/rag_apps.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, Path
 from fastapi.responses import JSONResponse
 
 from backend.logger import logger
+from backend.modules.metadata_store.base import BaseMetadataStore
 from backend.modules.metadata_store.client import get_client
 from backend.types import CreateRagApplication
 
@@ -13,54 +14,35 @@ async def register_rag_app(
     rag_app: CreateRagApplication,
 ):
     """Create a rag app"""
-    try:
-        logger.info(f"Creating rag app: {rag_app}")
-        client = await get_client()
-        created_rag_app = await client.acreate_rag_app(rag_app)
-        return JSONResponse(
-            content={"rag_app": created_rag_app.model_dump()}, status_code=201
-        )
-    except HTTPException as exp:
-        raise exp
-    except Exception as exp:
-        logger.exception("Failed to add rag app")
-        raise HTTPException(status_code=500, detail=str(exp))
+    logger.info(f"Creating rag app: {rag_app}")
+    metadata_store_client = await get_client()
+    created_rag_app = await metadata_store_client.acreate_rag_app(rag_app)
+    return JSONResponse(
+        content={"rag_app": created_rag_app.model_dump()}, status_code=201
+    )
 
 
 @router.get("/list")
 async def list_rag_apps():
     """Get rag apps"""
-    try:
-        client = await get_client()
-        rag_apps = await client.alist_rag_apps()
-        return JSONResponse(content={"rag_apps": rag_apps})
-    except Exception as exp:
-        logger.exception("Failed to get rag apps")
-        raise HTTPException(status_code=500, detail=str(exp))
+    metadata_store_client = await get_client()
+    rag_apps = await metadata_store_client.alist_rag_apps()
+    return JSONResponse(content={"rag_apps": rag_apps})
 
 
 @router.get("/{app_name}")
 async def get_rag_app_by_name(app_name: str = Path(title="App name")):
     """Get the rag app config given its name"""
-    try:
-        client = await get_client()
-        rag_app = await client.aget_rag_app(app_name)
-        if rag_app is None:
-            return JSONResponse(content={"rag_app": []})
-        return JSONResponse(content={"rag_app": rag_app.model_dump()})
-    except HTTPException as exp:
-        raise exp
+    metadata_store_client = await get_client()
+    rag_app = await metadata_store_client.aget_rag_app(app_name)
+    if rag_app is None:
+        return JSONResponse(content={"rag_app": []})
+    return JSONResponse(content={"rag_app": rag_app.model_dump()})
 
 
 @router.delete("/{app_name}")
 async def delete_rag_app(app_name: str = Path(title="App name")):
     """Delete the rag app config given its name"""
-    try:
-        client = await get_client()
-        await client.adelete_rag_app(app_name)
-        return JSONResponse(content={"deleted": True})
-    except HTTPException as exp:
-        raise exp
-    except Exception as exp:
-        logger.exception("Failed to delete rag app")
-        raise HTTPException(status_code=500, detail=str(exp))
+    metadata_store_client = await get_client()
+    await metadata_store_client.adelete_rag_app(app_name)
+    return JSONResponse(content={"deleted": True})

--- a/backend/server/routers/rag_apps.py
+++ b/backend/server/routers/rag_apps.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Path
+from fastapi import APIRouter, Depends, Path
 from fastapi.responses import JSONResponse
 
 from backend.logger import logger
@@ -12,10 +12,10 @@ router = APIRouter(prefix="/v1/apps", tags=["apps"])
 @router.post("")
 async def register_rag_app(
     rag_app: CreateRagApplication,
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
 ):
     """Create a rag app"""
     logger.info(f"Creating rag app: {rag_app}")
-    metadata_store_client = await get_client()
     created_rag_app = await metadata_store_client.acreate_rag_app(rag_app)
     return JSONResponse(
         content={"rag_app": created_rag_app.model_dump()}, status_code=201
@@ -23,17 +23,20 @@ async def register_rag_app(
 
 
 @router.get("/list")
-async def list_rag_apps():
+async def list_rag_apps(
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
+):
     """Get rag apps"""
-    metadata_store_client = await get_client()
     rag_apps = await metadata_store_client.alist_rag_apps()
     return JSONResponse(content={"rag_apps": rag_apps})
 
 
 @router.get("/{app_name}")
-async def get_rag_app_by_name(app_name: str = Path(title="App name")):
+async def get_rag_app_by_name(
+    app_name: str = Path(title="App name"),
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
+):
     """Get the rag app config given its name"""
-    metadata_store_client = await get_client()
     rag_app = await metadata_store_client.aget_rag_app(app_name)
     if rag_app is None:
         return JSONResponse(content={"rag_app": []})
@@ -41,8 +44,10 @@ async def get_rag_app_by_name(app_name: str = Path(title="App name")):
 
 
 @router.delete("/{app_name}")
-async def delete_rag_app(app_name: str = Path(title="App name")):
+async def delete_rag_app(
+    app_name: str = Path(title="App name"),
+    metadata_store_client: BaseMetadataStore = Depends(get_client),
+):
     """Delete the rag app config given its name"""
-    metadata_store_client = await get_client()
     await metadata_store_client.adelete_rag_app(app_name)
     return JSONResponse(content={"deleted": True})

--- a/backend/server/routers/rag_apps.py
+++ b/backend/server/routers/rag_apps.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Path
+from fastapi import APIRouter, Path
 from fastapi.responses import JSONResponse
 
 from backend.logger import logger
@@ -12,10 +12,10 @@ router = APIRouter(prefix="/v1/apps", tags=["apps"])
 @router.post("")
 async def register_rag_app(
     rag_app: CreateRagApplication,
-    metadata_store_client: BaseMetadataStore = Depends(get_client),
 ):
     """Create a rag app"""
     logger.info(f"Creating rag app: {rag_app}")
+    metadata_store_client: BaseMetadataStore = await get_client()
     created_rag_app = await metadata_store_client.acreate_rag_app(rag_app)
     return JSONResponse(
         content={"rag_app": created_rag_app.model_dump()}, status_code=201
@@ -23,10 +23,9 @@ async def register_rag_app(
 
 
 @router.get("/list")
-async def list_rag_apps(
-    metadata_store_client: BaseMetadataStore = Depends(get_client),
-):
+async def list_rag_apps():
     """Get rag apps"""
+    metadata_store_client: BaseMetadataStore = await get_client()
     rag_apps = await metadata_store_client.alist_rag_apps()
     return JSONResponse(content={"rag_apps": rag_apps})
 
@@ -34,9 +33,9 @@ async def list_rag_apps(
 @router.get("/{app_name}")
 async def get_rag_app_by_name(
     app_name: str = Path(title="App name"),
-    metadata_store_client: BaseMetadataStore = Depends(get_client),
 ):
     """Get the rag app config given its name"""
+    metadata_store_client: BaseMetadataStore = await get_client()
     rag_app = await metadata_store_client.aget_rag_app(app_name)
     if rag_app is None:
         return JSONResponse(content={"rag_app": []})
@@ -44,10 +43,8 @@ async def get_rag_app_by_name(
 
 
 @router.delete("/{app_name}")
-async def delete_rag_app(
-    app_name: str = Path(title="App name"),
-    metadata_store_client: BaseMetadataStore = Depends(get_client),
-):
+async def delete_rag_app(app_name: str = Path(title="App name")):
     """Delete the rag app config given its name"""
+    metadata_store_client: BaseMetadataStore = await get_client()
     await metadata_store_client.adelete_rag_app(app_name)
     return JSONResponse(content={"deleted": True})

--- a/backend/types.py
+++ b/backend/types.py
@@ -505,6 +505,11 @@ class ListDataIngestionRunsDto(ConfiguredBaseModel):
     )
 
 
+################################
+## RAG Application
+################################
+
+
 class RagApplication(ConfiguredBaseModel):
     # allow only small case alphanumeric and hyphen, should contain at least one alphabet and begin with alphabet
     name: Annotated[


### PR DESCRIPTION
- Remove `aget_retrieve_collection_by_name` since it's just a wrapper around `aget_collection_by_name`
- Remove `aget_retrieve_collection_by_name` from the base loader as a part of point 1.
- Use `find_first_or_raise` as exposed by the Prisma Python client while fetching records. This will raise `RecordNotFoundError` if not found.
- Remove unnecessary db calls to check if a record exists before creating one. Instead, use `UniqueViolationError` which is raised when a duplicate record is created.
- Wrap `adelete_collection` in a transaction context since multiple db operations are involved.
- Modify API to associate data sources with collection to accept multiple data sources simultaneously. Resolved `n+1` issue where the collection was being updated for each association
- Remove try-catch blocks in all routes where INTERNAL_SERVER_ERROR handling was done. Moved this to a global handler in `app.py` (thanks to @Blakeinstein )
- When datasource type is `truefoundry` (for localdir datasource creation), deleting a data source should delete the tfy data source. 
- Add more comments