### PR TITLE
fix: use signed_url instead of url for file upload

### DIFF
--- a/backend/types.py
+++ b/backend/types.py
@@ -315,7 +315,7 @@ class BaseDataSource(ConfiguredBaseModel):
         title="A unique identifier for the data source",
     )
     metadata: Optional[Dict[str, Any]] = Field(
-        None, title="Additional config for your data source"
+        default_factory=dict, title="Additional config for your data source"
     )
 
     @computed_field


### PR DESCRIPTION
- Fix a bug introduced due to the signed URL being sent in the key named `signed_url` instead of `url`
- Move the state update out of a for loop and update it once after collecting all new values.
- Add an empty `dict` as a default value for the metadata field in the data source type
- Stop sending `metadata = {}` while creating a data source when metadata is empty since we already have an empty dict as default.