### PR TITLE
feat: add read signed url of the vector chunks

### DIFF
--- a/backend/constants.py
+++ b/backend/constants.py
@@ -2,8 +2,31 @@ DATA_POINT_FQN_METADATA_KEY = "_data_point_fqn"
 
 DATA_POINT_HASH_METADATA_KEY = "_data_point_hash"
 
+DATA_POINT_SIGNED_URL_METADATA_KEY = "_signed_url"
+
+DATA_POINT_FILE_PATH_METADATA_KEY = "_data_point_file_path"
+
 DEFAULT_BATCH_SIZE = 100
 
 DEFAULT_BATCH_SIZE_FOR_VECTOR_STORE = 1000
 
 FQN_SEPARATOR = "::"
+
+# parser constants
+
+MULTI_MODAL_PARSER_PROMPT = """Given an image containing one or more charts/graphs, and texts, provide a detailed analysis of the data represented in the charts. Your task is to analyze the image and provide insights based on the data it represents.
+    Specifically, the information should include but not limited to:
+    Title of the Image: Provide a title from the charts or image if any.
+    Type of Chart: Determine the type of each chart (e.g., bar chart, line chart, pie chart, scatter plot, etc.) and its key features (e.g., labels, legends, data points).
+    Data Trends: Describe any notable trends or patterns visible in the data. This may include increasing/decreasing trends, seasonality, outliers, etc.
+    Key Insights: Extract key insights or observations from the charts. What do the charts reveal about the underlying data? Are there any significant findings that stand out?
+    Data Points: Identify specific data points or values represented in the charts, especially those that contribute to the overall analysis or insights.
+    Comparisons: Compare different charts within the same image or compare data points within a single chart. Highlight similarities, differences, or correlations between datasets.
+    Conclude with a summary of the key findings from your analysis and any recommendations based on those findings.
+"""
+MULTI_MODAL_PARSER_SUPPORTED_IMAGE_EXTENSIONS = [".png", ".jpeg", ".jpg"]
+MULTI_MODAL_PARSER_SUPPORTED_PDF_EXTENSION = [".pdf"]
+MULTI_MODAL_PARSER_SUPPORTED_FILE_EXTENSIONS = (
+    MULTI_MODAL_PARSER_SUPPORTED_IMAGE_EXTENSIONS
+    + MULTI_MODAL_PARSER_SUPPORTED_PDF_EXTENSION
+)

--- a/backend/indexer/indexer.py
+++ b/backend/indexer/indexer.py
@@ -1,13 +1,11 @@
 import tempfile
 from concurrent.futures import Executor
-from types import SimpleNamespace
 from typing import Dict, List, Optional
 
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 from langchain.docstore.document import Document
 from truefoundry.deploy import trigger_job
-from truefoundry.ml import DataDirectory
 
 from backend.constants import (
     DATA_POINT_FILE_PATH_METADATA_KEY,

--- a/backend/indexer/main.py
+++ b/backend/indexer/main.py
@@ -19,7 +19,6 @@ async def main():
     try:
         await ingest_data(request=inputs)
     except Exception as e:
-        print(f"Indexer exception - {e}")
         logger.exception(e)
         exit(1)
 

--- a/backend/modules/parsers/multi_modal_parser.py
+++ b/backend/modules/parsers/multi_modal_parser.py
@@ -11,6 +11,12 @@ from langchain.docstore.document import Document
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 
+from backend.constants import (
+    MULTI_MODAL_PARSER_PROMPT,
+    MULTI_MODAL_PARSER_SUPPORTED_FILE_EXTENSIONS,
+    MULTI_MODAL_PARSER_SUPPORTED_IMAGE_EXTENSIONS,
+    MULTI_MODAL_PARSER_SUPPORTED_PDF_EXTENSION,
+)
 from backend.logger import logger
 from backend.modules.model_gateway.model_gateway import model_gateway
 from backend.modules.parsers.parser import BaseParser
@@ -20,7 +26,7 @@ from backend.types import ModelConfig
 
 class MultiModalParser(BaseParser):
     """
-    MultiModalParser is a multi-modal parser class for deep extraction of pdf documents.
+    MultiModalParser is a multi-modal parser class for deep extraction of pdf documents and images.
 
     Parser Configuration will look like the following while creating the collection:
     {
@@ -36,7 +42,7 @@ class MultiModalParser(BaseParser):
     }
     """
 
-    supported_file_extensions = [".pdf", ".png", ".jpeg", ".jpg"]
+    supported_file_extensions = MULTI_MODAL_PARSER_SUPPORTED_FILE_EXTENSIONS
 
     def __init__(self, *, model_configuration: ModelConfig, prompt: str = "", **kwargs):
         """
@@ -50,32 +56,21 @@ class MultiModalParser(BaseParser):
             self.prompt = prompt
             logger.info(f"Using custom prompt..., {self.prompt}")
         else:
-            self.prompt = """Given an image containing one or more charts/graphs, and texts, provide a detailed analysis of the data represented in the charts. Your task is to analyze the image and provide insights based on the data it represents.
-Specifically, the information should include but not limited to:
-Title of the Image: Provide a title from the charts or image if any.
-Type of Chart: Determine the type of each chart (e.g., bar chart, line chart, pie chart, scatter plot, etc.) and its key features (e.g., labels, legends, data points).
-Data Trends: Describe any notable trends or patterns visible in the data. This may include increasing/decreasing trends, seasonality, outliers, etc.
-Key Insights: Extract key insights or observations from the charts. What do the charts reveal about the underlying data? Are there any significant findings that stand out?
-Data Points: Identify specific data points or values represented in the charts, especially those that contribute to the overall analysis or insights.
-Comparisons: Compare different charts within the same image or compare data points within a single chart. Highlight similarities, differences, or correlations between datasets.
-Conclude with a summary of the key findings from your analysis and any recommendations based on those findings."""
+            self.prompt = MULTI_MODAL_PARSER_PROMPT
+
+        self.llm = model_gateway.get_llm_from_model_config(self.model_configuration)
 
         super().__init__(**kwargs)
 
     async def call_vlm_agent(
-        self,
-        llm: BaseChatModel,
-        base64_image: str,
-        page_number: int,
-        prompt: str = "Describe the information present in the image in a structured format.",
-    ):
+        self, base64_image: str, page_number: int
+    ) -> Dict[str, Any]:
+        logger.info(f"Processing Image... {page_number}")
+
         content = [
             HumanMessage(
-                [
-                    {
-                        "type": "text",
-                        "text": prompt,
-                    },
+                content=[
+                    {"type": "text", "text": self.prompt},
                     {
                         "type": "image_url",
                         "image_url": {
@@ -86,129 +81,89 @@ Conclude with a summary of the key findings from your analysis and any recommend
                 ]
             )
         ]
-        logger.info(f"Processing Image... {page_number}")
 
         try:
-            response = await llm.ainvoke(content)
-            return {
-                "response": [
-                    page_number,
-                    response.content,
-                ]
-            }
+            response = await self.llm.ainvoke(content)
+            return {"response": (page_number, response.content)}
         except Exception as e:
-            logger.exception(f"Error in page: {page_number} - {e}")
-            return {"error": f"Error in page: {page_number}"}
+            error_message = f"Error processing page {page_number}: {str(e)}"
+            logger.exception(error_message)
+            return {"error": error_message}
 
     async def get_chunks(
-        self, filepath: str, metadata: Optional[Dict[Any, Any]] = None, *args, **kwargs
+        self, filepath: str, _metadata: Optional[Dict[Any, Any]] = None, *args, **kwargs
     ):
         """
-        Asynchronously extracts text from a PDF file and returns it in chunks.
+        Asynchronously extracts text from a PDF or image file and returns it in chunks.
         """
+        _file_path, file_name = os.path.split(filepath)
+        pages = self._get_pages(filepath)
+
         final_texts = []
-        try:
-            if (
-                not filepath.endswith(".pdf")
-                and not filepath.endswith(".png")
-                and not filepath.endswith(".jpeg")
-                and not filepath.endswith(".jpg")
-            ):
-                raise Exception(
-                    "Invalid file extension. MultiModalParser only supports PDF, PNG, JPEG, JPG files."
-                )
 
-            # get file path & name
-            file_path, file_name = os.path.split(filepath)
+        for page_chunk in self._chunk_pages(pages):
+            tasks = [
+                self.call_vlm_agent(image_b64, page_number)
+                for page_number, image_b64 in page_chunk.items()
+            ]
+            responses = await asyncio.gather(*tasks)
 
-            if filepath.endswith(".pdf"):
-                # Open the PDF file using pdfplumber
-                doc = fitz.open(filepath)
-                pages = {}
-
-                # Iterate over each page in the PDF
-                logger.info(f"\n\nLoading all pages...")
-                for page in doc:
-                    page_number = page.number + 1
-                    try:
-                        # Convert the page to an image (RGB mode)
-                        pix = page.get_pixmap(alpha=False)
-                        img = np.frombuffer(pix.samples, dtype=np.uint8).reshape(
-                            (pix.h, pix.w, pix.n)
+            for response in responses:
+                if response and "error" not in response:
+                    pg_no, page_content = response["response"]
+                    if contains_text(page_content):
+                        final_texts.append(
+                            self._create_document(
+                                file_name, pg_no, page_content, pages[pg_no]
+                            )
                         )
 
-                        # Convert the image to base64
-                        _, buffer = cv2.imencode(".png", img)
-                        image_base64 = base64.b64encode(buffer).decode("utf-8")
+            await asyncio.sleep(5)
 
-                        pages[page_number] = image_base64
-                    except Exception as e:
-                        logger.exception(f"Error in page: {page_number} - {e}")
-                        continue
+        return final_texts
 
-                logger.info(f"Total Pages: {len(pages)}")
+    def _get_pages(self, filepath: str) -> Dict[int, str]:
+        if filepath.endswith(MULTI_MODAL_PARSER_SUPPORTED_PDF_EXTENSION):
+            return self._get_pdf_pages(filepath)
+        elif filepath.endswith(MULTI_MODAL_PARSER_SUPPORTED_IMAGE_EXTENSIONS):
+            return self._get_image_page(filepath)
+        else:
+            raise ValueError(
+                "Invalid file extension. Supported formats: PDF, PNG, JPEG, JPG"
+            )
 
-            elif (
-                filepath.endswith(".png")
-                or filepath.endswith(".jpeg")
-                or filepath.endswith(".jpg")
-            ):
-                # Convert the image to base64
-                with open(filepath, "rb") as f:
-                    image_base64 = base64.b64encode(f.read()).decode("utf-8")
+    def _get_pdf_pages(self, filepath: str) -> Dict[int, str]:
+        pages = {}
+        doc = fitz.open(filepath)
+        for page in doc:
+            try:
+                pix = page.get_pixmap(alpha=False)
+                img = np.frombuffer(pix.samples, dtype=np.uint8).reshape(
+                    (pix.h, pix.w, pix.n)
+                )
+                _, buffer = cv2.imencode(".png", img)
+                pages[page.number + 1] = base64.b64encode(buffer).decode("utf-8")
+            except Exception as e:
+                logger.exception(f"Error in page {page.number + 1}: {e}")
+        return pages
 
-                pages = {0: image_base64}
+    def _get_image_page(self, filepath: str) -> Dict[int, str]:
+        with open(filepath, "rb") as f:
+            return {0: base64.b64encode(f.read()).decode("utf-8")}
 
-            # make parallel requests to VLM for all pages
-            prompt = self.prompt
+    def _chunk_pages(self, data: Dict[int, str], size: int = 30):
+        it = iter(data)
+        for i in range(0, len(data), size):
+            yield {k: data[k] for k in islice(it, size)}
 
-            def break_chunks(data, size=30):
-                it = iter(data)
-                for i in range(0, len(data), size):
-                    yield {k: data[k] for k in islice(it, size)}
-
-            llm = model_gateway.get_llm_from_model_config(self.model_configuration)
-            for page_items in break_chunks(pages):
-                tasks = [
-                    self.call_vlm_agent(
-                        llm=llm,
-                        base64_image=image_b64,
-                        page_number=page_number,
-                        prompt=prompt,
-                    )
-                    for page_number, image_b64 in page_items.items()
-                ]
-                responses = await asyncio.gather(*tasks)
-
-                logger.info(f"Total Responses: {len(responses)}")
-
-                if responses is not None:
-                    for response in responses:
-                        if response is not None:
-                            if "error" in response:
-                                logger.error(f"Error in page: {response['error']}")
-                                continue
-                            else:
-                                pg_no, page_content = response["response"]
-                                if contains_text(page_content):
-                                    logger.debug(f"Processed page: {pg_no}")
-                                    final_texts.append(
-                                        Document(
-                                            page_content="File Name: "
-                                            + file_name
-                                            + "\n\n"
-                                            + page_content,
-                                            metadata={
-                                                "image_b64": pages[pg_no],
-                                                "page_number": pg_no,
-                                                "source": file_name,
-                                            },
-                                        )
-                                    )
-                else:
-                    logger.debug("No response from VLM...")
-                await asyncio.sleep(5)
-            return final_texts
-        except Exception as e:
-            logger.exception(f"Final Exception: {e}")
-            raise e
+    def _create_document(
+        self, file_name: str, pg_no: int, page_content: str, image_b64: str
+    ) -> Document:
+        return Document(
+            page_content=f"File Name: {file_name}\n\n{page_content}",
+            metadata={
+                "image_b64": image_b64,
+                "page_number": pg_no,
+                "source": file_name,
+            },
+        )

--- a/backend/modules/parsers/multi_modal_parser.py
+++ b/backend/modules/parsers/multi_modal_parser.py
@@ -8,7 +8,6 @@ import cv2
 import fitz
 import numpy as np
 from langchain.docstore.document import Document
-from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 
 from backend.constants import (

--- a/backend/modules/query_controllers/base.py
+++ b/backend/modules/query_controllers/base.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import re
 from typing import AsyncIterator
 
@@ -13,7 +12,6 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from pydantic import BaseModel
 
 from backend.constants import (
-    DATA_POINT_FILE_PATH_METADATA_KEY,
     DATA_POINT_FQN_METADATA_KEY,
     DATA_POINT_HASH_METADATA_KEY,
     DATA_POINT_SIGNED_URL_METADATA_KEY,
@@ -24,7 +22,6 @@ from backend.modules.model_gateway.model_gateway import model_gateway
 from backend.modules.query_controllers.types import *
 from backend.modules.vector_db.client import VECTOR_STORE_CLIENT
 from backend.settings import settings
-from backend.types import Collection
 from backend.utils import _get_read_signed_url_with_cache
 
 

--- a/backend/modules/query_controllers/base.py
+++ b/backend/modules/query_controllers/base.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import re
 from typing import AsyncIterator
 
 import async_timeout
@@ -11,20 +12,30 @@ from langchain.schema.vectorstore import VectorStoreRetriever
 from langchain_core.language_models.chat_models import BaseChatModel
 from pydantic import BaseModel
 
+from backend.constants import (
+    DATA_POINT_FILE_PATH_METADATA_KEY,
+    DATA_POINT_FQN_METADATA_KEY,
+    DATA_POINT_HASH_METADATA_KEY,
+    DATA_POINT_SIGNED_URL_METADATA_KEY,
+)
 from backend.logger import logger
 from backend.modules.metadata_store.client import get_client
 from backend.modules.model_gateway.model_gateway import model_gateway
 from backend.modules.query_controllers.types import *
 from backend.modules.vector_db.client import VECTOR_STORE_CLIENT
 from backend.settings import settings
-from backend.types import Collection, ModelConfig
+from backend.types import Collection
+from backend.utils import _get_read_signed_url_with_cache
 
 
 class BaseQueryController:
     required_metadata = [
-        "_data_point_fqn",
-        "filename",
         "_id",
+        DATA_POINT_FQN_METADATA_KEY,
+        DATA_POINT_HASH_METADATA_KEY,
+        DATA_POINT_SIGNED_URL_METADATA_KEY,
+        "_data_source_fqn",
+        "filename",
         "collection_name",
         "page_number",
         "pg_no",
@@ -39,17 +50,7 @@ class BaseQueryController:
         return PromptTemplate(input_variables=input_variables, template=template)
 
     def _format_docs(self, docs):
-        formatted_docs = list()
-        for doc in docs:
-            metadata = {
-                key: doc.metadata[key]
-                for key in self.required_metadata
-                if key in doc.metadata
-            }
-            formatted_docs.append(
-                {"page_content": doc.page_content, "metadata": metadata}
-            )
-        return "\n\n".join([f"{doc['page_content']}" for doc in formatted_docs])
+        return "\n\n".join([doc.page_content for doc in docs])
 
     def _get_llm(self, model_configuration: ModelConfig, stream=False) -> BaseChatModel:
         """
@@ -63,11 +64,6 @@ class BaseQueryController:
         """
         client = await get_client()
         collection = await client.aget_collection_by_name(collection_name)
-        if collection is None:
-            raise HTTPException(status_code=404, detail="Collection not found")
-
-        if not isinstance(collection, Collection):
-            collection = Collection(**collection.model_dump())
 
         return VECTOR_STORE_CLIENT.get_vector_store(
             collection_name=collection.name,
@@ -169,18 +165,88 @@ class BaseQueryController:
             raise HTTPException(status_code=404, detail="Retriever not found")
         return retriever
 
-    def _cleanup_metadata(self, docs):
-        formatted_docs = list()
+    def _enrich_context_for_stream_response(
+        self, docs, artifact_repo_cache, signed_url_cache
+    ):
+        """
+        Enrich the context for the stream response
+        """
+        enriched_docs = []
+
         for doc in docs:
-            metadata = {
-                key: doc.metadata[key]
-                for key in self.required_metadata
-                if key in doc.metadata
-            }
-            formatted_docs.append(
-                Document(page_content=doc.page_content, metadata=metadata)
+            # Enrich the original doc with signed URL
+            enriched_doc = self._enrich_metadata_with_signed_url(
+                doc, artifact_repo_cache, signed_url_cache
             )
-        return formatted_docs
+
+            # Create a new Document with only the required metadata
+            enriched_docs.append(
+                Document(
+                    page_content=enriched_doc.page_content,
+                    metadata={
+                        key: enriched_doc.metadata[key]
+                        for key in self.required_metadata
+                        if key in enriched_doc.metadata
+                    },
+                )
+            )
+
+        return enriched_docs
+
+    def _enrich_context_for_non_stream_response(self, outputs):
+        """
+        Enrich the context for the non stream response
+        """
+        if "context" not in outputs:
+            return []
+
+        # Cache to store the artifact repo paths for the current request
+        artifact_repo_cache = {}
+        # Cache to store the signed urls for the files for the current request
+        signed_url_cache = {}
+
+        return [
+            self._enrich_metadata_with_signed_url(
+                doc, artifact_repo_cache, signed_url_cache
+            )
+            for doc in outputs["context"]
+        ]
+
+    def _enrich_metadata_with_signed_url(
+        self, doc, artifact_repo_cache, signed_url_cache=None
+    ):
+        """
+        Enrich the metadata with the signed url
+        """
+        fqn_with_source = doc.metadata.get(DATA_POINT_FQN_METADATA_KEY)
+
+        # Return if FQN is not present or if it's already in the cache
+        if not fqn_with_source or fqn_with_source in signed_url_cache:
+            return doc
+
+        # Use a single regex to extract both data-dir FQN and file path
+        match = re.search(r"(data-dir:[^:]+).*?(files/.+)$", fqn_with_source)
+
+        # Return if the regex does not match
+        if not match:
+            return doc
+
+        # Extract the data-dir FQN and the file path from the FQN with source
+        data_dir_fqn, file_path = match.groups()
+
+        # Generate a signed url for the file
+        signed_url = _get_read_signed_url_with_cache(
+            fqn=data_dir_fqn,
+            file_path=file_path,
+            cache=artifact_repo_cache,
+        )
+
+        # Add the signed url to the metadata if it's not None
+        if signed_url:
+            doc.metadata[DATA_POINT_SIGNED_URL_METADATA_KEY] = signed_url[0].signed_url
+            signed_url_cache[fqn_with_source] = signed_url
+
+        return doc
 
     def _intent_summary_search(self, query: str):
         url = f"https://api.search.brave.com/res/v1/web/search?q={query}&summary=1"
@@ -222,15 +288,26 @@ class BaseQueryController:
     async def _sse_wrap(self, gen):
         async for data in gen:
             yield "event: data\n"
-            yield f"data: {json.dumps(data.dict())}\n\n"
+            yield f"data: {data.model_dump_json()}\n\n"
         yield "event: end\n"
 
     async def _stream_answer(self, rag_chain, query) -> AsyncIterator[BaseModel]:
         async with async_timeout.timeout(GENERATION_TIMEOUT_SEC):
             try:
+                # Caches to store the artifact repo paths and signed urls for the current request
+                artifact_repo_cache = {}
+                # Cache to store the signed urls for the files for the current request
+                signed_url_cache = {}
+                # Process each chunk of the stream
                 async for chunk in rag_chain.astream(query):
+                    # If the chunk has the context key, enrich the context with the signed urls
                     if "context" in chunk:
-                        yield Docs(content=self._cleanup_metadata(chunk["context"]))
+                        yield Docs(
+                            content=self._enrich_context_for_stream_response(
+                                chunk["context"], artifact_repo_cache, signed_url_cache
+                            )
+                        )
+                    # If the chunk has the answer key, yield the answer
                     elif "answer" in chunk:
                         yield Answer(content=chunk["answer"])
             except asyncio.TimeoutError:

--- a/backend/modules/query_controllers/example/controller.py
+++ b/backend/modules/query_controllers/example/controller.py
@@ -1,9 +1,8 @@
-from fastapi import Body, HTTPException
+from fastapi import Body
 from fastapi.responses import StreamingResponse
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.runnables import RunnableParallel, RunnablePassthrough
 
-from backend.logger import logger
 from backend.modules.query_controllers.base import BaseQueryController
 from backend.modules.query_controllers.example.payload import (
     QUERY_WITH_CONTEXTUAL_COMPRESSION_MULTI_QUERY_RETRIEVER_SIMILARITY_PAYLOAD,


### PR DESCRIPTION
- Add a function to fetch artifacts of the data directory by data dir fqn.
- Add function to get `read signed URL` of a data dir and local file path
- Add `_signed_url` in the Q/A API response to enable UI to reference and provide links to the source files.
- Handle metadata enrichment for stream and nonstream response types.
- Refactor `MultiModalParser`
  - Move default multi-modal parser prompt to constants
  - Move LLM instance creation to `__init__`
  - Remove unnecessary passing of instance objects like prompt, and llm between functions and use instance vars instead.
- Upgrade `langchain-openai` from `0.1.20` to `0.1.25` to fix issues introduced in https://github.com/truefoundry/cognita/pull/371
- Remove unused libraries: `openai` and `orjson`
- Closes https://github.com/truefoundry/cognita/issues/363