### PR TITLE
Integrate Crawl4Ai to scrape web content

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 public.ecr.aws/docker/library/python:3.11
+FROM --platform=linux/amd64 python:3.11
 
 # Required for opencv
 RUN apt-get update -y && \
@@ -14,7 +14,8 @@ COPY backend/vectordb.requirements.txt /tmp/vectordb.requirements.txt
 
 # Install Python packages
 RUN python3 -m pip install -U pip setuptools wheel uv && \
-    python3 -m uv pip install --no-cache-dir -r /tmp/requirements.txt --index-strategy unsafe-any-match
+    python3 -m uv pip install --no-cache-dir -r /tmp/requirements.txt --index-strategy unsafe-any-match && \
+    playwright install --with-deps
 
 # Install VectorDB packages
 ARG ADD_VECTORDB=0

--- a/backend/indexer/indexer.py
+++ b/backend/indexer/indexer.py
@@ -163,7 +163,7 @@ async def _sync_data_source_to_collection(
             data_ingestion_mode=inputs.data_ingestion_mode,
         )
 
-        for loaded_data_points_batch in loaded_data_points_batch_iterator:
+        async for loaded_data_points_batch in loaded_data_points_batch_iterator:
             try:
                 await ingest_data_points(
                     inputs=inputs,

--- a/backend/modules/dataloaders/loader.py
+++ b/backend/modules/dataloaders/loader.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Iterator, List
+from typing import AsyncGenerator, Dict, List
 
 from backend.types import DataIngestionMode, DataSource, LoadedDataPoint
 
@@ -36,7 +36,7 @@ class BaseDataLoader(ABC):
     Base data loader class. Data loader is responsible for detecting, filtering and then loading data points to be ingested.
     """
 
-    def load_full_data(
+    async def load_full_data(
         self,
         data_source: DataSource,
         dest_dir: str,
@@ -51,7 +51,7 @@ class BaseDataLoader(ABC):
         Returns:
             None
         """
-        return self.load_filtered_data(
+        return await self.load_filtered_data(
             data_source,
             dest_dir,
             previous_snapshot={},
@@ -59,7 +59,7 @@ class BaseDataLoader(ABC):
             data_ingestion_mode=DataIngestionMode.FULL,
         )
 
-    def load_incremental_data(
+    async def load_incremental_data(
         self,
         data_source: DataSource,
         dest_dir: str,
@@ -76,7 +76,7 @@ class BaseDataLoader(ABC):
         Returns:
             None
         """
-        return self.load_filtered_data(
+        return await self.load_filtered_data(
             data_source,
             dest_dir,
             previous_snapshot,
@@ -85,14 +85,14 @@ class BaseDataLoader(ABC):
         )
 
     @abstractmethod
-    def load_filtered_data(
+    async def load_filtered_data(
         self,
         data_source: DataSource,
         dest_dir: str,
         previous_snapshot: Dict[str, str],
         batch_size: int,
         data_ingestion_mode: DataIngestionMode,
-    ) -> Iterator[List[LoadedDataPoint]]:
+    ) -> AsyncGenerator[List[LoadedDataPoint], None]:
         """
         Sync the data source, filter data points and load them from the source to the destination directory.
         This method returns the loaded data points in batches as an iterator.

--- a/backend/modules/dataloaders/local_dir_loader.py
+++ b/backend/modules/dataloaders/local_dir_loader.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from typing import Dict, Iterator, List
+from typing import AsyncGenerator, Dict, List
 
 from backend.logger import logger
 from backend.modules.dataloaders.loader import BaseDataLoader
@@ -12,14 +12,14 @@ class LocalDirLoader(BaseDataLoader):
     Load data from a local directory
     """
 
-    def load_filtered_data(
+    async def load_filtered_data(
         self,
         data_source: DataSource,
         dest_dir: str,
         previous_snapshot: Dict[str, str],
         batch_size: int,
         data_ingestion_mode: DataIngestionMode,
-    ) -> Iterator[List[LoadedDataPoint]]:
+    ) -> AsyncGenerator[List[LoadedDataPoint], None]:
         """
         Loads data from a local directory specified by the given source URI.
         """

--- a/backend/modules/dataloaders/truefoundry_loader.py
+++ b/backend/modules/dataloaders/truefoundry_loader.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Iterator, List
+from typing import AsyncGenerator, Dict, List
 
 from truefoundry.ml import get_client as get_tfy_client
 
@@ -14,14 +14,14 @@ class TrueFoundryLoader(BaseDataLoader):
     Load data from a TrueFoundry data source (data-dir).
     """
 
-    def load_filtered_data(
+    async def load_filtered_data(
         self,
         data_source: DataSource,
         dest_dir: str,
         previous_snapshot: Dict[str, str],
         batch_size: int,
         data_ingestion_mode: DataIngestionMode,
-    ) -> Iterator[List[LoadedDataPoint]]:
+    ) -> AsyncGenerator[List[LoadedDataPoint], None]:
         """
         Loads data from a truefoundry data directory with FQN specified by the given source URI.
         """
@@ -48,7 +48,7 @@ class TrueFoundryLoader(BaseDataLoader):
         # If tfy_files_dir is None, it means the data was not downloaded.
         if tfy_files_dir is None:
             logger.error("Download info not found")
-            return iter([])
+            raise ValueError("Failed to download data directory")
 
         if os.path.exists(os.path.join(tfy_files_dir, "files")):
             logger.debug("Files directory exists")

--- a/backend/modules/parsers/__init__.py
+++ b/backend/modules/parsers/__init__.py
@@ -3,9 +3,11 @@ from backend.modules.parsers.multi_modal_parser import MultiModalParser
 from backend.modules.parsers.parser import register_parser
 from backend.modules.parsers.unstructured_io import UnstructuredIoParser
 from backend.modules.parsers.video_parser import VideoParser
+from backend.modules.parsers.web_parser import WebParser
 
 # The order of registry defines the order of precedence
 register_parser("UnstructuredIoParser", UnstructuredIoParser)
 register_parser("MultiModalParser", MultiModalParser)
 register_parser("AudioParser", AudioParser)
 register_parser("VideoParser", VideoParser)
+register_parser("WebParser", WebParser)

--- a/backend/modules/parsers/unstructured_io.py
+++ b/backend/modules/parsers/unstructured_io.py
@@ -20,7 +20,6 @@ class UnstructuredIoParser(BaseParser):
         ".html",
         ".md",
         ".rst",
-        ".json",
         ".rtf",
         ".jpeg",
         ".png",

--- a/backend/modules/parsers/web_parser.py
+++ b/backend/modules/parsers/web_parser.py
@@ -1,0 +1,162 @@
+import os
+from typing import Any, Dict, List, Optional
+
+import aiofiles
+import aiofiles.os
+from crawl4ai import AsyncWebCrawler
+from crawl4ai.extraction_strategy import LLMExtractionStrategy
+from langchain.docstore.document import Document
+from pydantic import BaseModel
+
+from backend.logger import logger
+from backend.modules.model_gateway.model_gateway import model_gateway
+from backend.modules.parsers.parser import PARSER_REGISTRY, BaseParser
+
+
+class WebModelConfig(BaseModel):
+    name: str
+    prompt: str
+
+
+class FinalParserConfig(BaseModel):
+    name: str
+    parameters: Optional[Dict[str, Any]] = None
+
+
+class WebParserConfig(BaseModel):
+    js_code: Optional[str] = None
+    wait_for: Optional[str] = None
+    css_selector: Optional[str] = None
+    llm_extraction_config: Optional[WebModelConfig] = None
+    final_parser: Optional[FinalParserConfig] = FinalParserConfig(
+        name="UnstructuredIoParser"
+    )
+
+
+class WebParser(BaseParser):
+    """
+    WebParser is a parser class for extracting text from audio input.
+
+    {
+        "url": {
+            "name": "WebParser",
+            "parameters": {
+                "js_code": "",
+                "wait_for": "",
+                "css_selector": "article",
+                "llm_extraction_config": {
+                    "name": "openai/gpt-4o-mini",
+                    "prompt": "Summarize the webpage"
+                },
+                "final_parser": {
+                    "name": "UnstructuredIoParser",
+                    "parameters": {}
+                }
+            }
+        }
+    }
+
+    """
+
+    supported_file_extensions = [
+        "url",
+    ]
+
+    def __init__(self, *, max_chunk_size: int = 2000, **kwargs):
+        """
+        Initializes the AudioParser object.
+        """
+        self.config = WebParserConfig.model_validate(kwargs)
+
+        self.max_chunk_size = max_chunk_size
+        super().__init__(**kwargs)
+
+    def model_config_to_extraction_strategy(
+        self, model_config: WebModelConfig
+    ) -> LLMExtractionStrategy:
+        model_provider_config = model_gateway.get_model_provider_config(
+            model_config.name
+        )
+
+        model_params = model_config.get("parameters", {})
+
+        if not model_provider_config.api_key_env_var:
+            api_key = "EMPTY"
+        else:
+            api_key = os.environ.get(model_provider_config.api_key_env_var, "")
+
+        os.environ["LITELLM_PROXY_API_KEY"] = api_key
+        os.environ["LITELLM_PROXY_API_BASE"] = model_provider_config.base_url
+        model_id = "litellm_proxy" + "/".join(model_config.name.split("/")[1:])
+        return LLMExtractionStrategy(
+            instruction=model_config.prompt,
+            model=model_id,
+            api_token=api_key,
+            temperature=model_params.get("temperature", 0.1),
+            default_headers=model_provider_config.default_headers,
+        )
+
+    async def get_chunks(
+        self, url: str, metadata: Dict[Any, Any] | None, **kwargs
+    ) -> List[Document]:
+        """
+        Get the chunks of the audio file.
+        """
+
+        if self.config.final_parser.name not in PARSER_REGISTRY:
+            raise ValueError(
+                f"Final parser {self.config.final_parser} not registered in the parser registry."
+            )
+
+        try:
+            extraction_strategy = None
+            if self.config.llm_extraction_config:
+                if not self.config.prompt:
+                    raise ValueError("Prompt is required for model configuration.")
+                extraction_strategy = self.model_config_to_extraction_strategy(
+                    self.config.llm_extraction_config
+                )
+
+            async with AsyncWebCrawler(verbose=True) as crawler:
+                result = await crawler.arun(
+                    url=url,
+                    bypass_cache=True,
+                    js_code=self.config.js_code,
+                    wait_for=self.config.wait_for,
+                    css_selector=self.config.css_selector,
+                    extraction_strategy=extraction_strategy,
+                )
+                assert result.success, f"Failed to crawl the page: {url}"
+
+                data = result.extracted_content
+                file_ext = ".json"
+
+                tempfile_name = None
+
+                async with aiofiles.tempfile.NamedTemporaryFile(
+                    mode="w", suffix=file_ext, delete=False
+                ) as temp_file:
+                    await temp_file.write(data)
+                    tempfile_name = temp_file.name
+
+                # Split the text into chunks
+                parser: BaseParser = PARSER_REGISTRY[self.config.final_parser.name](
+                    **(self.config.final_parser.parameters or {})
+                )
+
+                final_texts = await parser.get_chunks(
+                    filepath=tempfile_name, metadata=metadata
+                )
+
+                # Remove the temporary file
+                try:
+                    await aiofiles.os.remove(tempfile_name)
+                    logger.info(f"Removed temporary file: {tempfile_name}")
+                except Exception as e:
+                    logger.exception(f"Error in removing temporary file: {e}")
+
+                return final_texts
+
+        except Exception as e:
+            logger.exception(f"Error in getting chunks: {e}")
+            raise e

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -62,4 +62,4 @@ black==24.3.0
 pre-commit==3.7.0
 
 ### Web Crawling
-crawl4ai==0.3.5
+crawl4ai==0.3.73

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,11 +17,10 @@ pydantic-settings==2.6.1
 PyMuPDF==1.23.6
 
 ## html
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
 
 ## markdown
 markdownify==0.11.6
-markdown-crawler==0.0.8
 
 ## async
 async-timeout==4.0.3
@@ -37,7 +36,7 @@ requests==2.32.2
 opencv-python==4.9.0.80
 
 ## pillow
-pillow==10.3.0
+pillow==10.4.0
 
 ## truefoundry
 truefoundry==0.4.1
@@ -61,3 +60,6 @@ qdrant-client==1.9.0
 autoflake==2.3.1
 black==24.3.0
 pre-commit==3.7.0
+
+### Web Crawling
+crawl4ai==0.3.5

--- a/deployment/indexer.py
+++ b/deployment/indexer.py
@@ -88,8 +88,8 @@ class Indexer:
             resources=Resources(
                 cpu_request=1.0,
                 cpu_limit=1.5,
-                memory_request=1000,
-                memory_limit=1500,
+                memory_request=2000,
+                memory_limit=4000,
                 ephemeral_storage_request=1000,
                 ephemeral_storage_limit=2000,
                 node=NodepoolSelector(),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -198,6 +198,8 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - BRAVE_API_KEY=${BRAVE_API_KEY}
     entrypoint: /bin/bash
+    security_opt:
+      - seccomp:./seccomp.json
     command: -c "set -e; prisma db push --schema ./backend/database/schema.prisma && uvicorn --host 0.0.0.0 --port 8000 backend.server.app:app --reload"
     networks:
       - cognita-docker

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@import-meta-env/cli": "^0.7.0",
     "@import-meta-env/unplugin": "^0.6.0",
-    "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/line-clamp": "^0.4.4",
     "@tailwindcss/typography": "^0.5.2",
     "@types/lodash": "^4.17.6",
@@ -86,6 +85,7 @@
     "react-dropzone": "^14.2.3",
     "react-error-boundary": "^4.0.13",
     "react-helmet-async": "^2.0.5",
+    "react-hook-form": "^7.53.0",
     "react-icons": "^5.2.1",
     "react-infinite-scroll-component": "^6.1.0",
     "react-loader-spinner": "^6.1.6",
@@ -93,7 +93,9 @@
     "react-promise-tracker": "^2.1.0",
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.2.2",
+    "react-syntax-highlighter": "^15.6.1",
     "react-toastify": "^10.0.5",
+    "rehype-raw": "^7.0.0",
     "sse.js": "^2.5.0",
     "tailwind-merge": "^2.3.0",
     "use-react-router-breadcrumbs": "^4.0.1"

--- a/frontend/src/components/base/atoms/CodeBlock.tsx
+++ b/frontend/src/components/base/atoms/CodeBlock.tsx
@@ -1,0 +1,35 @@
+import classNames from "classnames";
+import React, { ClassAttributes, HTMLAttributes } from "react";
+import { ExtraProps } from "react-markdown";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {okaidia} from 'react-syntax-highlighter/dist/esm/styles/prism'
+import Button from "./Button";
+import CopyField from "./CopyField";
+
+export type CodeBlockProps = {
+  language: string;
+  value: string;
+};
+
+const CodeBlock: React.FC<ClassAttributes<HTMLElement> & HTMLAttributes<HTMLElement> & ExtraProps> = ({children, className, node, ...rest}) => {
+  const match = /language-(\w+)/.exec(className || '')
+
+  return match ? (
+    <span className="relative">
+      <CopyField rawValue={String(children)} className="absolute top-2 right-2" />
+      <SyntaxHighlighter
+        {...rest}
+        PreTag="div"
+        children={String(children).replace(/\n$/, '')}
+        language={match[1]}
+        style={okaidia}
+      />
+    </span>
+    ) : (
+      <code {...rest} className={classNames('p-1 text-sm bg-gray-800 text-white rounded-md', className)}>
+        {children}
+      </code>
+    )
+}
+
+export default CodeBlock;

--- a/frontend/src/components/base/atoms/Markdown.tsx
+++ b/frontend/src/components/base/atoms/Markdown.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
+import type { Root } from 'mdast';
+import { visit } from 'unist-util-visit';
+import rehypeRaw from "rehype-raw";
 
 import classNames from '@/utils/classNames'
 import { InfoType } from '@/types/enums'
+import CodeBlock from "./CodeBlock";
 
 export type MarkdownProps = React.ComponentProps<typeof ReactMarkdown> & {
   type?: InfoType
@@ -13,6 +17,14 @@ const Markdown: React.FC<MarkdownProps> = ({ children, className }) => {
   return (
     <ReactMarkdown
       className={classes}
+      remarkPlugins={[
+        () => (tree: Root) => {
+          visit(tree, 'code', (node) => {
+            node.lang = node.lang ?? 'plaintext';
+          });
+        },
+      ]}
+      rehypePlugins={[rehypeRaw]}
       children={children}
       components={{
         li: ({
@@ -43,6 +55,7 @@ const Markdown: React.FC<MarkdownProps> = ({ children, className }) => {
             </span>
           )
         },
+        code: CodeBlock,
       }}
     />
   )

--- a/frontend/src/components/base/atoms/Picker.tsx
+++ b/frontend/src/components/base/atoms/Picker.tsx
@@ -1,0 +1,34 @@
+import { MenuItem, Select, type SelectProps } from '@mui/material'
+import React from 'react'
+
+type PickerProps = {
+  options: string[]
+}
+
+const Picker = React.forwardRef<typeof Select, PickerProps & SelectProps<string>>((props, ref) => {
+  return (
+    <Select
+      ref={ref}
+      {...props}
+      placeholder="Select Model..."
+      sx={{
+        background: 'white',
+        height: '2rem',
+        width: '13.1875rem',
+        border: '1px solid #CEE0F8 !important',
+        outline: 'none !important',
+        '& fieldset': {
+          border: 'none !important',
+        },
+      }}
+    >
+      {props.options.map((option: string) => (
+        <MenuItem value={option} key={option}>
+          {option}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+})
+
+export default Picker;

--- a/frontend/src/components/base/atoms/Switch.tsx
+++ b/frontend/src/components/base/atoms/Switch.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface SwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(({ checked, onChange, ...rest }, ref) => {
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      className="toggle toggle-primary"
+      {...rest}
+      checked={checked}
+      onChange={(e) => onChange(e.target.checked)}
+    />
+  );
+})
+
+export default Switch;

--- a/frontend/src/screens/dashboard/docsqa/AddDataSourceToCollection.tsx
+++ b/frontend/src/screens/dashboard/docsqa/AddDataSourceToCollection.tsx
@@ -66,6 +66,7 @@ const AddDataSourceToCollection = ({
         data_ingestion_mode: 'INCREMENTAL',
         raise_error_on_failure: true,
         run_as_job: true,
+        batch_size: 30,
       })
 
       onClose()

--- a/frontend/src/screens/dashboard/docsqa/DataSources/FileUpload.tsx
+++ b/frontend/src/screens/dashboard/docsqa/DataSources/FileUpload.tsx
@@ -1,0 +1,240 @@
+import React, { useMemo } from 'react'
+import { useController, useFormContext } from 'react-hook-form'
+import classNames from 'classnames'
+
+import { FormInputData } from './FormType'
+import { getUniqueFiles } from '@/utils/artifacts'
+import IconProvider from '@/components/assets/IconProvider'
+import { DOCS_QA_MAX_UPLOAD_SIZE_MB } from '@/stores/constants'
+import { DarkTooltip } from '@/components/base/atoms/Tooltip'
+import Badge from '@/components/base/atoms/Badge'
+import Button from '@/components/base/atoms/Button'
+import Spinner from '@/components/base/atoms/Spinner'
+
+const parseFileSize = (size: number) => {
+  const units = ['B', 'Ki', 'Mi', 'Gi']
+  let i = 0
+  while (size >= 1024) {
+    size /= 1024
+    ++i
+  }
+  const hasDecimal = size % 1 !== 0
+  return `${hasDecimal ? size.toFixed(2) : size} ${units[i]}`
+}
+
+const calcUploadSize = (files: FormInputData['localdir']['files']) =>
+  files.reduce((acc, { file }) => acc + file.size, 0) / 1024 / 1024
+
+type Props =  {
+  uploadedFileIds: string[]
+}
+
+const FileUpload: React.FC<Props> = ({ uploadedFileIds }) => {
+  const { control, register, formState: {errors, isSubmitting} } = useFormContext<FormInputData>()
+
+  const { field, fieldState } = useController({
+    name: 'localdir.files',
+    control,
+    rules: {
+      required: true,
+      validate: {
+        notEmpty: (files) => files.length > 0 || 'Please upload at least one file',
+        maxSize: (files) =>
+          calcUploadSize(files) <= DOCS_QA_MAX_UPLOAD_SIZE_MB ||
+        `Total upload size cannot be more than ${DOCS_QA_MAX_UPLOAD_SIZE_MB}MB`,
+      },
+    },
+    defaultValue: [],
+  })
+
+  const handleDrop = (e: React.DragEvent<HTMLLabelElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    field.onChange(
+      [...field.value, ...getUniqueFiles(e.dataTransfer.files)],
+    )
+  }
+
+  const removeFile = (id: string) => {
+    field.onChange(field.value.filter((f) => f.id !== id))
+  }
+
+  return <div>
+    <div className="mb-2">
+      <label className="form-control">
+        <div className='label'>
+          <span className="label-text font-inter">
+            Source Name * <small>
+              (Should only contain lowercase alphanumeric character
+              with hyphen (-))
+            </small>
+          </span>
+        </div>
+        <input
+          className={classNames(
+            'block w-full border border-gray-250 outline-none text-md p-2 rounded',
+            {
+              'field-error': errors?.localdir?.name,
+            }
+          )}
+          {...register(
+            "localdir.name",
+            {
+              required: true,
+              pattern: {
+                value: /^[a-z0-9-]+$/,
+                message: 'Source name should only contain lowercase alphanumeric character with hyphen!'
+              }
+            })
+          }
+          placeholder='Enter the source name'
+        />
+      </label>
+      {errors?.localdir?.name && (
+        <div className="text-error text-xs mt-1 flex gap-1 items-center">
+          <IconProvider
+            icon="exclamation-triangle"
+            className={'w-4 leading-5'}
+          />
+          <div className="font-medium">
+            {errors.localdir.name.message}
+          </div>
+        </div>
+      )}
+    </div>
+    <label
+      className='space-y-2'
+      onDragOver={
+        isSubmitting
+          ? undefined
+          : (e) => {
+              e.stopPropagation()
+              e.preventDefault()
+            }
+      }
+      onDrop={isSubmitting ? undefined : handleDrop}
+    >
+      <span className="label-text font-inter mb-1">
+        Choose files or a zip to upload
+      </span>
+      <div
+        className={classNames(
+          'flex flex-col flex-1 justify-center items-center w-full h-full bg-white p-4 rounded-lg border-1 border-gray-200 border-dashed',
+          {
+            'hover:bg-gray-100 cursor-pointer': !isSubmitting,
+            'cursor-default': isSubmitting,
+          }
+        )}
+      >
+        <div className="text-gray-600 flex flex-col justify-center items-center p-3 gap-2">
+          <IconProvider icon="cloud-arrow-up" size={2} />
+          <p className="text-sm leading-5 mb-2 text-center">
+            <span className="font-[500]">
+              Click or Drag &amp; Drop to upload files
+            </span>
+            <span className="block">
+              Limit {DOCS_QA_MAX_UPLOAD_SIZE_MB}MB in total • zip,
+              txt, md
+            </span>
+          </p>
+        </div>
+        <input
+          disabled={isSubmitting}
+          className="hidden"
+          type="file"
+          multiple
+          ref={field.ref}
+          name={field.name}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            field.onChange(
+              [
+                ...field.value,
+                ...getUniqueFiles(e.target.files),
+              ],
+            )
+          }
+        />
+      </div>
+    </label>
+
+    {field.value.length > 0 &&  (
+      <div
+        className={classNames(
+          'flex flex-col gap-2 p-2 bg-white border rounded-md mt-2',
+          'max-h-[calc(100vh-30.625rem)]'
+        )}
+      >
+        <span className="text-sm flex justify-between">
+          Selected Files ({field.value.length}){' '}
+          {fieldState.error?.message && (
+            <span className="text-xs text-red-700">
+              { fieldState.error.message }
+            </span>
+          )}
+        </span>
+
+        <ul
+          className={classNames(
+            'overflow-y-auto',
+            'max-h-[calc(100vh-33.5rem)]'
+          )}
+        >
+          {field.value.map(({ id, file }, idx) => (
+            <li
+              key={id}
+              className="flex flex-row gap-2 p-2 bg-white shadow rounded-lg border mb-2 justify-between items-center"
+            >
+              <div className="flex items-center gap-2">
+                {idx + 1}.
+                <div className="flex flex-col gap-1">
+                  <div className="font-inter text-sm leading-4">
+                    {file.name}
+                  </div>
+                  <DarkTooltip title={`${file.size} bytes`}>
+                    <Badge
+                      text={parseFileSize(file.size)}
+                      type="gray"
+                      className="cursor-default"
+                    />
+                  </DarkTooltip>
+                </div>
+              </div>
+
+              {isSubmitting ? (
+                <div
+                  className={classNames(
+                    'w-5 h-5 rounded-full flex items-center justify-center',
+                    {
+                      'bg-emerald-100 text-emerald-800':
+                        uploadedFileIds.includes(id),
+                    }
+                  )}
+                >
+                  {uploadedFileIds.includes(id) ? (
+                    <IconProvider
+                      icon={'fa-check'}
+                      className="text-emerald-800"
+                    />
+                  ) : (
+                    <Spinner small />
+                  )}
+                </div>
+              ) : (
+                <Button
+                  type="button"
+                  icon="trash-alt"
+                  iconClasses="text-xs text-gray-400"
+                  className="btn-sm bg-white hover:bg-white hover:border-gray-500"
+                  onClick={() => removeFile(id)}
+                  white
+                />
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    )}
+  </div>
+}
+
+export default FileUpload

--- a/frontend/src/screens/dashboard/docsqa/DataSources/FileUpload.tsx
+++ b/frontend/src/screens/dashboard/docsqa/DataSources/FileUpload.tsx
@@ -133,8 +133,7 @@ const FileUpload: React.FC<Props> = ({ uploadedFileIds }) => {
               Click or Drag &amp; Drop to upload files
             </span>
             <span className="block">
-              Limit {DOCS_QA_MAX_UPLOAD_SIZE_MB}MB in total • zip,
-              txt, md
+              Limit {DOCS_QA_MAX_UPLOAD_SIZE_MB}MB in total
             </span>
           </p>
         </div>

--- a/frontend/src/screens/dashboard/docsqa/DataSources/FormType.ts
+++ b/frontend/src/screens/dashboard/docsqa/DataSources/FormType.ts
@@ -1,0 +1,15 @@
+export type FormInputData = {
+  dataSourceType: string
+  localdir: {
+    name: string
+    files: {
+      id: string
+      file: File
+    }[]
+    uploadedFileIds: string[]
+  }
+  dataSourceUri: string
+  webConfig: {
+    use_sitemap: boolean
+  }
+}

--- a/frontend/src/screens/dashboard/docsqa/DataSources/NewDataSource.tsx
+++ b/frontend/src/screens/dashboard/docsqa/DataSources/NewDataSource.tsx
@@ -1,17 +1,16 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import { MenuItem, Select } from '@mui/material'
-import { set, startCase } from 'lodash'
+import React, { useEffect, useState } from 'react'
+import { useForm, SubmitHandler, Controller, FormProvider } from "react-hook-form"
+import { startCase } from 'lodash'
 import { uploadArtifactFileWithSignedURI } from '@/api/truefoundry'
-import IconProvider from '@/components/assets/IconProvider'
-import Badge from '@/components/base/atoms/Badge'
 import Button from '@/components/base/atoms/Button'
 import CustomDrawer from '@/components/base/atoms/CustomDrawer'
 import Spinner from '@/components/base/atoms/Spinner'
-import { DarkTooltip } from '@/components/base/atoms/Tooltip'
 import notify from '@/components/base/molecules/Notify'
 import {
-  DOCS_QA_MAX_UPLOAD_SIZE_MB,
   IS_LOCAL_DEVELOPMENT,
+  LOCAL_SOURCE_NAME,
+  TFY_SOURCE_NAME,
+  WEB_SOURCE_NAME,
 } from '@/stores/constants'
 import {
   customerId,
@@ -20,21 +19,14 @@ import {
   useUploadDataToDataDirectoryMutation,
   useUploadDataToLocalDirectoryMutation,
 } from '@/stores/qafoundry'
-import { getFilePath, getUniqueFiles } from '@/utils/artifacts'
 import classNames from '@/utils/classNames'
 import axios from 'axios'
+import WebDataSource from './WebDataSource'
+import { FormInputData } from './FormType'
+import FileUpload from './FileUpload'
+import { getFilePath } from '@/utils/artifacts'
+import { data } from 'autoprefixer'
 
-
-const parseFileSize = (size: number) => {
-  const units = ['B', 'Ki', 'Mi', 'Gi']
-  let i = 0
-  while (size >= 1024) {
-    size /= 1024
-    ++i
-  }
-  const hasDecimal = size % 1 !== 0
-  return `${hasDecimal ? size.toFixed(2) : size} ${units[i]}`
-}
 
 type FileObject = {
   id: string
@@ -48,37 +40,23 @@ interface NewDataSourceProps {
 const NewDataSource: React.FC<NewDataSourceProps> = ({ onClose }) => {
   const [isNewDataSourceDrawerOpen, setIsNewDataSourceDrawerOpen] =
     React.useState(false)
-  const [isSaving, setIsSaving] = useState(false)
-  const [selectedDataSourceType, setSelectedDataSourceType] = useState('')
-  const [dataSourceUri, setDataSourceUri] = useState('')
-  const [uploadedFileIds, setUploadedFileIds] = React.useState<string[]>([])
-  const [uploadName, setUploadName] = useState('')
-  const [uploadSizeMb, setUploadSizeMb] = React.useState(0)
-  const [files, setFiles] = React.useState<{ id: string; file: File }[]>([])
-  const { data: dataLoaders, isLoading } = useGetDataLoadersQuery()
 
+  const [localUploadedFileIds, setLocalUploadedFileIds] = useState<string[]>([])
 
-  const pattern = /^[a-z][a-z0-9-]*$/
-  const isValidUploadName = pattern.test(uploadName)
+  const { data: dataLoaders } = useGetDataLoadersQuery()
+
 
   const [uploadDataToDataDirectory] = useUploadDataToDataDirectoryMutation()
   const [uploadDataToLocalDirectory] = useUploadDataToLocalDirectoryMutation()
   const [addDataSource] = useAddDataSourceMutation()
 
-  useEffect(() => {
-    let size = 0
-    files.forEach((f) => (size += f.file.size))
-    size = size / (1024 * 1024)
-    setUploadSizeMb(size)
-  }, [files])
 
-  useEffect(() => {
-    if (dataLoaders && !selectedDataSourceType)
-      setSelectedDataSourceType(dataLoaders[0]?.type)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataLoaders])
+  const close = () => {
+    setIsNewDataSourceDrawerOpen(false)
+    onClose()
+  }
 
-  const uploadDocs = async () => {
+  const uploadDocs = async (uploadName: string, files: FormInputData['localdir']['files']) => {
     try {
       const entries: any = files.map((fileObj: FileObject) => [
         getFilePath(fileObj.file),
@@ -110,7 +88,9 @@ const NewDataSource: React.FC<NewDataSourceProps> = ({ onClose }) => {
         );
 
         // Update the uploaded file ids state, filtering out null values
-        setUploadedFileIds((prev) => [...prev, ...uploadedFileIds.filter(Boolean)]);
+        setLocalUploadedFileIds(
+          [...localUploadedFileIds, ...uploadedFileIds.filter(Boolean)]
+        );
       }
       return dataDirectoryFqn
     } catch (err) {
@@ -118,29 +98,23 @@ const NewDataSource: React.FC<NewDataSourceProps> = ({ onClose }) => {
     }
   }
 
-  const handleDrop = (e: any) => {
-    e.stopPropagation()
-    e.preventDefault()
-    setFiles([...files, ...getUniqueFiles(e.dataTransfer.files)])
-  }
 
-  const resetForm = () => {
-    setFiles([])
-    setDataSourceUri('')
-    setSelectedDataSourceType(dataLoaders[0]?.type || 'none')
-    setIsSaving(false)
-  }
+  const methods = useForm<FormInputData>({ mode: 'onChange'})
 
-  const close = () => {
-    setIsNewDataSourceDrawerOpen(false)
-    onClose()
-  }
+  const selectedDataSourceType = methods.watch('dataSourceType')
 
-  const handleSubmit = async () => {
-    setIsSaving(true)
+  const onSubmit: SubmitHandler<FormInputData> = async (data) => {
     try {
-      if (selectedDataSourceType === 'localdir' && !files.length) {
-        setIsSaving(false)
+      if (!methods.formState.isValid) {
+        return notify(
+          'error',
+          'Invalid Form!',
+          Object.values(methods.formState?.errors || {})
+            .map((e) => e.message).join(', ')
+            || 'Please fill all required fields'
+        )
+      }
+      if (data.dataSourceType === 'localdir' && !data.localdir) {
         return notify(
           'error',
           'Files are required!',
@@ -148,31 +122,45 @@ const NewDataSource: React.FC<NewDataSourceProps> = ({ onClose }) => {
         )
       }
       let fqn
-      if (selectedDataSourceType === 'localdir') {
-        let res
-        if (IS_LOCAL_DEVELOPMENT) {
-          res = await uploadDataToLocalDirectory({
-            files: files?.map((f) => f.file),
-            upload_name: uploadName,
-          }).unwrap()
-        } else {
-          const ddFqn = await uploadDocs()
+      let res: { data_source: { fqn: string } }
+      switch (data.dataSourceType) {
+        case LOCAL_SOURCE_NAME:
+          if (IS_LOCAL_DEVELOPMENT) {
+            res = await uploadDataToLocalDirectory({
+              files: data.localdir.files.map((f) => f.file),
+              upload_name: data.localdir.name,
+            }).unwrap()
+          } else {
+            const ddFqn = await uploadDocs(data.localdir.name, data.localdir.files)
+            res = await addDataSource({
+              type: TFY_SOURCE_NAME,
+              uri: ddFqn
+            }).unwrap()
+          }
+          break;
+        case TFY_SOURCE_NAME:
           res = await addDataSource({
-            type: 'truefoundry',
-            uri: ddFqn
+            type: selectedDataSourceType,
+            uri: data.dataSourceUri,
+            metadata: {
+              customerId: customerId,
+            },
           }).unwrap()
-        }
-        fqn = res.data_source?.fqn
-      } else {
-        const res = await addDataSource({
-          type: selectedDataSourceType,
-          uri: dataSourceUri,
-          metadata: {
-            customerId: customerId,
-          },
-        }).unwrap()
-        fqn = res.data_source?.fqn
+          break;
+        case WEB_SOURCE_NAME:
+          res = await addDataSource({
+            type: WEB_SOURCE_NAME,
+            uri: data.dataSourceUri,
+            metadata: {
+              use_sitemap: data.webConfig.use_sitemap,
+            },
+          }).unwrap()
+          break;
+        default:
+          throw new Error('Invalid data source type')
       }
+
+      fqn = res.data_source?.fqn
 
       close()
       resetForm()
@@ -191,7 +179,19 @@ const NewDataSource: React.FC<NewDataSourceProps> = ({ onClose }) => {
           'There was an error while adding documents to collection.'
       )
     }
-    setIsSaving(false)
+  }
+
+  useEffect(() => {
+    resetForm()
+  }, [dataLoaders])
+
+  const resetForm = () => {
+    if (dataLoaders?.[0]?.type) {
+      methods.reset({
+        dataSourceType: dataLoaders[0].type,
+      })
+      setLocalUploadedFileIds([])
+    }
   }
 
   return (
@@ -205,7 +205,7 @@ const NewDataSource: React.FC<NewDataSourceProps> = ({ onClose }) => {
         />
       <CustomDrawer
         anchor={'right'}
-        open={isNewDataSourceDrawerOpen }
+        open={isNewDataSourceDrawerOpen}
         onClose={() => {
           close()
           resetForm()
@@ -213,285 +213,120 @@ const NewDataSource: React.FC<NewDataSourceProps> = ({ onClose }) => {
         bodyClassName="z-2"
         width="w-[65vw]"
       >
-        <div className="relative w-full">
-          {isSaving && (
-            <div className="absolute w-full h-full bg-gray-50 z-10 flex flex-col justify-center items-center">
+        <FormProvider {...methods}>
+          <form className="relative w-full" onSubmit={methods.handleSubmit(onSubmit)}>
+            {methods.formState.isSubmitting && (
+              <div className="absolute w-full h-full bg-gray-50 z-10 flex flex-col justify-center items-center">
+                <div>
+                  <Spinner center big />
+                </div>
+                <p className="mt-4">Data Source is being created...</p>
+              </div>
+            )}
+            <div className="font-bold font-inter text-2xl py-2 border-b border-gray-200 px-4">
+              Create New Data Source
+            </div>
+            <div className="h-[calc(100vh-124px)] p-4 overflow-auto">
+              <div className="bg-yellow-100 p-2 my-4 text-xs rounded">
+                Documents that are uploaded will be accessible to the public.
+                Please do not upload any confidential or sensitive data.
+              </div>
               <div>
-                <Spinner center big />
-              </div>
-              <p className="mt-4">Data Source is being created...</p>
-            </div>
-          )}
-          <div className="font-bold font-inter text-2xl py-2 border-b border-gray-200 px-4">
-            Create New Data Source
-          </div>
-          <div className="h-[calc(100vh-124px)] p-4">
-            <div className="bg-yellow-100 p-2 my-4 text-xs rounded">
-              Documents that are uploaded will be accessible to the public.
-              Please do not upload any confidential or sensitive data.
-            </div>
-            <div>
-              <div className="mb-2">
-                <div className="label-text font-inter mb-1">
-                  Data Source Type
-                </div>
-                <div className='grid grid-cols-2 gap-2'>
-                  {dataLoaders?.map((source: any) => (
-                    <button
-                      key={source.type}
-                      className={classNames(
-                        'flex p-4 rounded-lg border border-gray-200 active:scale-95 transition-all',
-                        {
-                          'bg-gray-700 text-white': selectedDataSourceType === source.type,
-                          'hover:bg-gray-100': selectedDataSourceType !== source.type,
-                        }
-                      )}
-                      onClick={() => {
-                        setDataSourceUri('')
-                        setFiles([])
-                        setSelectedDataSourceType(source.type)
-                      }}
-                      type='button'
-                    >
-                      <div className="capitalize">
-                        <h5 className='text-lg font-semibold text-left'>{startCase(source.type)}</h5>
-                        {source.description && (
-                          <div className="text-sm text-gray-500">
-                            ({source.description})
-                          </div>
-                        )}
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              </div>
-              {selectedDataSourceType === 'localdir' ? (
-                <>
-                  <div className="mb-2">
-                    <label htmlFor="collection-name-input">
-                      <span className="label-text font-inter mb-1">
-                        Source Name
-                      </span>
-                      <small>
-                        {' '}
-                        * Should only contain lowercase alphanumeric character
-                        with hyphen (-)
-                      </small>
-                    </label>
-                    <input
-                      className={classNames(
-                        'block w-full border border-gray-250 outline-none text-md p-2 rounded',
-                        {
-                          'field-error': uploadName && !isValidUploadName,
-                        }
-                      )}
-                      id="collection-name-input"
-                      placeholder={'Enter the source name'}
-                      value={uploadName}
-                      onChange={(e) => setUploadName(e.target.value)}
-                    />
-                    {uploadName && !isValidUploadName && (
-                      <div className="text-error text-xs mt-1 flex gap-1 items-center">
-                        <IconProvider
-                          icon="exclamation-triangle"
-                          className={'w-4 leading-5'}
-                        />
-                        <div className="font-medium">
-                          Source name should only contain lowercase alphanumeric
-                          character with hyphen!
-                        </div>
-                      </div>
-                    )}
+                <div className="mb-2">
+                  <div className="label-text font-inter mb-1">
+                    Data Source Type
                   </div>
-                  <label
-                    onDragOver={
-                      isSaving
-                        ? undefined
-                        : (e) => {
-                            e.stopPropagation()
-                            e.preventDefault()
-                          }
-                    }
-                    onDrop={isSaving ? undefined : handleDrop}
-                  >
-                    <span className="label-text font-inter mb-1">
-                      Choose files or a zip to upload
-                    </span>
-                    <div
-                      className={classNames(
-                        'flex flex-col flex-1 justify-center items-center w-full h-full bg-white p-4 rounded-lg border-1 border-gray-200 border-dashed',
-                        {
-                          'hover:bg-gray-100 cursor-pointer': !isSaving,
-                          'cursor-default': isSaving,
-                        }
-                      )}
-                    >
-                      <div className="text-gray-600 flex flex-col justify-center items-center p-3 gap-2">
-                        <IconProvider icon="cloud-arrow-up" size={2} />
-                        <p className="text-sm leading-5 mb-2 text-center">
-                          <span className="font-[500]">
-                            Click or Drag &amp; Drop to upload files
-                          </span>
-                          <span className="block">
-                            Limit {DOCS_QA_MAX_UPLOAD_SIZE_MB}MB in total
-                          </span>
-                        </p>
-                      </div>
-                      <input
-                        disabled={isSaving}
-                        className="hidden"
-                        id="dropzone-file"
-                        type="file"
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                          setFiles([
-                            ...files,
-                            ...getUniqueFiles(e.target.files),
-                          ])
-                        }
-                        multiple
-                      />
-                    </div>
-                  </label>
-                </>
-              ) : (
-                <>
-                  <label htmlFor="collection-name-input">
-                    <span className="label-text font-inter mb-1">
-                      {selectedDataSourceType === 'github'
-                        ? 'GitHub Repo URL'
-                        : selectedDataSourceType === 'truefoundry'
-                        ? 'Data Source FQN'
-                        : selectedDataSourceType === 'artifact'
-                        ? 'Artifact Version FQN'
-                        : 'URL'}
-                    </span>
-                  </label>
-                  <input
-                    className="block w-full border border-gray-250 outline-none text-md p-2 rounded"
-                    id="collection-name-input"
-                    placeholder={`${
-                      selectedDataSourceType === 'github'
-                        ? 'Enter GitHub Repo URL'
-                        : selectedDataSourceType === 'truefoundry'
-                        ? 'Enter Data Source FQN'
-                        : selectedDataSourceType === 'artifact'
-                        ? 'Enter Artifact Version FQN'
-                        : 'Enter Web URL'
-                    }`}
-                    value={dataSourceUri}
-                    onChange={(e) => setDataSourceUri(e.target.value)}
-                  />
-                </>
-              )}
-              {!!files.length && selectedDataSourceType === 'localdir' && (
-                <div
-                  className={classNames(
-                    'flex flex-col gap-2 p-2 bg-white border rounded-md mt-2',
-                    'max-h-[calc(100vh-30.625rem)]'
-                  )}
-                >
-                  <span className="text-sm flex justify-between">
-                    Selected Files ({files.length}){' '}
-                    {uploadSizeMb > DOCS_QA_MAX_UPLOAD_SIZE_MB && (
-                      <span className="text-xs text-red-700">
-                        Selected files total size cannot be more than{' '}
-                        {DOCS_QA_MAX_UPLOAD_SIZE_MB}
-                        MB
-                      </span>
-                    )}
-                  </span>
-
-                  <ul
-                    className={classNames(
-                      'overflow-y-auto',
-                      'max-h-[calc(100vh-33.5rem)]'
-                    )}
-                  >
-                    {files.map(({ id, file }, idx) => (
-                      <li
-                        key={id}
-                        className="flex flex-row gap-2 p-2 bg-white shadow rounded-lg border mb-2 justify-between items-center"
-                      >
-                        <div className="flex items-center gap-2">
-                          {idx + 1}.
-                          <div className="flex flex-col gap-1">
-                            <div className="font-inter text-sm leading-4">
-                              {file.name}
-                            </div>
-                            <DarkTooltip title={`${file.size} bytes`}>
-                              <Badge
-                                text={parseFileSize(file.size)}
-                                type="gray"
-                                className="cursor-default"
-                              />
-                            </DarkTooltip>
-                          </div>
-                        </div>
-
-                        {isSaving ? (
-                          <div
+                  {dataLoaders && <Controller
+                    name="dataSourceType"
+                    control={methods.control}
+                    defaultValue={dataLoaders[0].type}
+                    render={({ field }) => <div className='grid grid-cols-2 gap-2'>
+                        {dataLoaders.map((source: any) => (
+                          <button
+                            key={source.type}
                             className={classNames(
-                              'w-5 h-5 rounded-full flex items-center justify-center',
+                              'flex p-4 rounded-lg border border-gray-200 active:scale-95 transition-all',
                               {
-                                'bg-emerald-100 text-emerald-800':
-                                  uploadedFileIds.includes(id),
+                                'bg-gray-700 text-white': field.value === source.type,
+                                'hover:bg-gray-100': field.value !== source.type,
                               }
                             )}
+                            onClick={() => {
+                              methods.reset({
+                                dataSourceType: source.type,
+                              })
+                            }}
+                            type='button'
                           >
-                            {uploadedFileIds.includes(id) ? (
-                              <IconProvider
-                                icon={'fa-check'}
-                                className="text-emerald-800"
-                              />
-                            ) : (
-                              <Spinner small />
-                            )}
-                          </div>
-                        ) : (
-                          <Button
-                            type="button"
-                            icon="trash-alt"
-                            iconClasses="text-xs text-gray-400"
-                            className="btn-sm bg-white hover:bg-white hover:border-gray-500"
-                            onClick={() =>
-                              setFiles(files.filter((f) => f.id !== id))
-                            }
-                            white
-                          />
-                        )}
-                      </li>
-                    ))}
-                  </ul>
+                            <div className="capitalize">
+                              <h5 className='text-lg font-semibold text-left'>{startCase(source.type)}</h5>
+                              {source.description && (
+                                <div className="text-sm text-gray-500">
+                                  ({source.description})
+                                </div>
+                              )}
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    }
+                  />}
+
                 </div>
-              )}
+                <div className="my-4 flex flex-col gap-2">
+                  {selectedDataSourceType === WEB_SOURCE_NAME && (
+                    <WebDataSource />
+                  )}
+                  {selectedDataSourceType === LOCAL_SOURCE_NAME && (
+                    <FileUpload
+                      uploadedFileIds={localUploadedFileIds}
+                    />
+                  )}
+                  {[TFY_SOURCE_NAME].includes(selectedDataSourceType) && (
+                    <label className="form-control">
+                      <div className='label'>
+                        <span className="label-text font-inter">
+                          {selectedDataSourceType === 'truefoundry'
+                            ? 'Data Source FQN *'
+                            : 'Artifact Version FQN *'}
+                        </span>
+                      </div>
+                      <input
+                        className="block w-full border border-gray-250 outline-none text-md p-2 rounded"
+                        {...methods.register("dataSourceUri", { required: true })}
+                        placeholder={`${
+                          selectedDataSourceType === 'truefoundry'
+                            ? 'Enter Data Source FQN'
+                            : 'Enter Artifact Version FQN'
+                        }`}
+                      />
+                    </label>
+                  )}
+                </div>
+
+              </div>
             </div>
-          </div>
-          <div className="flex justify-end items-center gap-2 h-[58px] border-t border-gray-200 px-4">
-            <Button
-              text="Cancel"
-              onClick={() => {
-                onClose()
-                resetForm()
-              }}
-              className="border-gray-500 gap-1 btn-sm font-normal"
-              type="button"
-            />
-            <Button
-              text="Submit"
-              onClick={handleSubmit}
-              className="gap-1 btn-sm font-normal btn-neutral"
-              type="button"
-              disabled={
-                isSaving ||
-                (selectedDataSourceType === 'localdir' &&
-                  (files.length === 0 ||
-                    uploadSizeMb > DOCS_QA_MAX_UPLOAD_SIZE_MB ||
-                    !uploadName ||
-                    !isValidUploadName))
-              }
-            />
-          </div>
-        </div>
+            <div className="flex justify-end items-center gap-2 h-[58px] border-t border-gray-200 px-4">
+              <Button
+                text="Cancel"
+                onClick={() => {
+                  onClose()
+                }}
+                className="border-gray-500 gap-1 btn-sm font-normal"
+                type="reset"
+              />
+              <Button
+                text="Submit"
+                className="gap-1 btn-sm font-normal btn-neutral"
+                type="submit"
+                disabled={
+                  methods.formState.isSubmitting ||
+                  !methods.formState.isValid
+                }
+              />
+            </div>
+          </form>
+        </FormProvider>
       </CustomDrawer>
     </>
   )

--- a/frontend/src/screens/dashboard/docsqa/DataSources/WebDataSource.tsx
+++ b/frontend/src/screens/dashboard/docsqa/DataSources/WebDataSource.tsx
@@ -1,0 +1,77 @@
+import React from "react"
+
+import Switch from "@/components/base/atoms/Switch"
+
+import Picker from "@/components/base/atoms/Picker"
+import SimpleCodeEditor from "@/components/base/molecules/SimpleCodeEditor"
+import { Controller, useFormContext } from "react-hook-form"
+import { FormInputData } from "./FormType"
+import { useGetAllEnabledChatModelsQuery } from "@/stores/qafoundry"
+import { WEBPAGE_URL_REGEX } from "@/stores/constants"
+import IconProvider from "@/components/assets/IconProvider"
+
+type Props = {}
+
+const WebDataSource: React.FC<Props> = () => {
+  const { register, unregister, control, formState: { errors } } = useFormContext<FormInputData>()
+
+  const { data: allEnabledModels } = useGetAllEnabledChatModelsQuery()
+
+  return (
+    <>
+      <label className="form-control">
+        <div className="label">
+          <span className="label-text font-inter">Web URL * <small>(Link to the page to scrape)</small></span>
+        </div>
+        <input
+          className="block w-full border border-gray-250 outline-none text-md p-2 rounded"
+          placeholder="Link to web page"
+          {...register(
+            "dataSourceUri",
+            {
+              required: true,
+              pattern: {
+                value: new RegExp(WEBPAGE_URL_REGEX),
+                message: "Not a valid URL"
+              }
+            })
+          }
+        />
+        {errors?.dataSourceUri && (
+          <div className="text-error text-xs mt-1 flex gap-1 items-center">
+            <IconProvider
+              icon="exclamation-triangle"
+              className={'w-4 leading-5'}
+            />
+            <div className="font-medium">
+              {errors.dataSourceUri.message}
+            </div>
+          </div>
+        )}
+      </label>
+      <div className="form-control">
+        <label className="label cursor-pointer">
+          <span className="label-text font-inter">Use Sitemap</span>
+          <Controller
+            name="webConfig.use_sitemap"
+            control={control}
+            render={({ field }) => (
+              <Switch
+                {...field}
+                checked={field.value}
+                onChange={(e) => field.onChange(e)}
+              />
+            )}
+          />
+        </label>
+      </div>
+
+      <div className="bg-green-100 p-2 text-xs rounded">
+        We will attempt to look for a sitemap at the root of the website.
+        Otherwise, we will scrape the website directly.
+      </div>
+    </>
+  )
+}
+
+export default WebDataSource

--- a/frontend/src/screens/dashboard/docsqa/DocsQA/DocLink.tsx
+++ b/frontend/src/screens/dashboard/docsqa/DocsQA/DocLink.tsx
@@ -1,8 +1,9 @@
 import IconProvider from '@/components/assets/IconProvider';
 import { customerId } from '@/stores/qafoundry';
 import classNames from 'classnames';
-import React from 'react'
+import React, { MouseEventHandler } from 'react'
 import { PreviewResource } from './types';
+import { WEB_SOURCE_NAME } from '@/stores/constants';
 
 type DocLinkProps = {
   pageNumber?: number;
@@ -11,13 +12,20 @@ type DocLinkProps = {
   loadPreview?: (resourse: PreviewResource) => void;
 };
 
-const LINK_RENDERING_SUPPORTED: string[] = []
+const LINK_RENDERING_SUPPORTED: string[] = [WEB_SOURCE_NAME]
 
 const DocLink = ({ pageNumber, fqn, fileFormat, loadPreview }: DocLinkProps) => {
   const splittedFqn = fqn.split('::');
 
   const isUrlHandlerSupport = LINK_RENDERING_SUPPORTED.includes(splittedFqn[0].toLowerCase())
-  const clickHandler = async () => {
+
+  const isDirectLink = splittedFqn[0] === WEB_SOURCE_NAME
+
+  const clickHandler: MouseEventHandler = async (e) => {
+    if (isDirectLink) {
+      return
+    }
+    e.preventDefault();
     switch(splittedFqn[0].toLowerCase()) {
       default:
         break;
@@ -28,9 +36,12 @@ const DocLink = ({ pageNumber, fqn, fileFormat, loadPreview }: DocLinkProps) => 
     <a
       className={
         classNames("text-sm text-indigo-600 mt-1 flex gap-1 items-center", {
-          'cursor-pointer': isUrlHandlerSupport
+          'cursor-pointer': isUrlHandlerSupport || isDirectLink
         })
       }
+      href={isDirectLink ? `https://${splittedFqn[2]}` : '#'}
+      referrerPolicy='no-referrer'
+      target='_blank'
       onClick={clickHandler}
     >
       Source: {splittedFqn?.[splittedFqn.length - 1]}

--- a/frontend/src/screens/dashboard/docsqa/DocsQA/DocLink.tsx
+++ b/frontend/src/screens/dashboard/docsqa/DocsQA/DocLink.tsx
@@ -39,7 +39,7 @@ const DocLink = ({ pageNumber, fqn, fileFormat, loadPreview }: DocLinkProps) => 
           'cursor-pointer': isUrlHandlerSupport || isDirectLink
         })
       }
-      href={isDirectLink ? `https://${splittedFqn[2]}` : '#'}
+      href={isDirectLink ? splittedFqn[2] : '#'}
       referrerPolicy='no-referrer'
       target='_blank'
       onClick={clickHandler}

--- a/frontend/src/screens/dashboard/docsqa/DocsQA/DocPreviewSlideOut.tsx
+++ b/frontend/src/screens/dashboard/docsqa/DocsQA/DocPreviewSlideOut.tsx
@@ -7,6 +7,7 @@ import CustomDrawer from "@/components/base/atoms/CustomDrawer"
 import IconProvider from "@/components/assets/IconProvider";
 import type { PreviewResource } from "./types";
 import { getFileFromS3 } from "@/utils/file";
+import { WEB_SOURCE_NAME } from "@/stores/constants";
 
 type Props = {
   onClose: () => void
@@ -18,6 +19,10 @@ const PreviewHandler: React.FC<{ name: string, fileFormat: string, previewUrl?: 
 
   if (!previewUrl) {
     return <div className={classes}>No preview available</div>
+  }
+
+  if (fileFormat === WEB_SOURCE_NAME) {
+    return <iframe src={previewUrl} className={classes} />
   }
 
   const [document, setDocument] = useState<File | null>(null)
@@ -67,7 +72,7 @@ const DocPreviewSlideOut: React.FC<Props> = ({ onClose, previewResource }) => {
       </div>
       {
         previewResource.fileFormat
-          ? <PreviewHandler previewUrl={previewResource.presignedUrl} name={previewResource.name} fileFormat={previewResource.fileFormat} />
+          ? <PreviewHandler previewUrl={previewResource.presignedUrl || previewResource.externalUrl} name={previewResource.name} fileFormat={previewResource.fileFormat} />
           : <span>
             No Preview available as file format unknown.
           </span>

--- a/frontend/src/screens/dashboard/docsqa/DocsQaInformation.tsx
+++ b/frontend/src/screens/dashboard/docsqa/DocsQaInformation.tsx
@@ -24,7 +24,7 @@ const DocsQaInformation = ({ header, subHeader }: DocsQaInformationProps) => {
         </div>
         <div className="flex items-center">
           <div className="w-[2.5rem] h-[0.0625rem] bg-black"></div>
-          <div className="border w-0 h-0 border-t border-t-[transparent] border-t-[0.25rem] border-b border-b-[transparent] border-b-[0.25rem] border-l border-l-[0.375rem] border-l-black"></div>
+          <div className="border w-0 h-0 border-t-[transparent] border-t-[0.25rem] border-b-[transparent] border-b-[0.25rem] border-l-[0.375rem] border-l-black"></div>
         </div>
         <div className="h-[10rem] w-[10rem] rounded-xl border border-gray-250 flex justify-end items-center flex-col pt-6">
           <img src={SearchIcon} className="h-[70.0625rem]" />
@@ -32,7 +32,7 @@ const DocsQaInformation = ({ header, subHeader }: DocsQaInformationProps) => {
         </div>
         <div className="flex items-center">
           <div className="w-[2.5rem] h-[0.0625rem] bg-black"></div>
-          <div className="border w-0 h-0 border-t border-t-[transparent] border-t-[0.25rem] border-b border-b-[transparent] border-b-[0.25rem] border-l border-l-[0.375rem] border-l-black"></div>
+          <div className="border w-0 h-0 border-t-[transparent] border-t-[0.25rem] border-b-[transparent] border-b-[0.25rem] border-l-[0.375rem] border-l-black"></div>
         </div>
         <div className="h-[10rem] w-[10rem] rounded-xl border border-gray-250 flex justify-end items-center flex-col pt-6">
           <div>
@@ -41,7 +41,7 @@ const DocsQaInformation = ({ header, subHeader }: DocsQaInformationProps) => {
             </div>
             <div className="flex flex-col justify-center items-center">
               <div className="h-[0.625rem] w-[0.0625rem] bg-black"></div>
-              <div className="border w-0 h-0 border-l border-l-[transparent] border-l-[0.25rem] border-r border-r-[transparent] border-r-[0.25rem] border-t border-t-[0.375rem] border-t-black"></div>
+              <div className="border w-0 h-0 border-l-[transparent] border-l-[0.25rem] border-r-[transparent] border-r-[0.25rem] border-t-[0.375rem] border-t-black"></div>
             </div>
             <div className="w-[5.75rem] py-2 rounded border border-gray-500 text-center text-white text-sm bg-indigo-500">
               Response

--- a/frontend/src/screens/dashboard/docsqa/NewCollection.tsx
+++ b/frontend/src/screens/dashboard/docsqa/NewCollection.tsx
@@ -91,6 +91,7 @@ const NewCollection = ({ open, onClose, onSuccess }: NewCollectionProps) => {
         data_ingestion_mode: 'INCREMENTAL',
         raise_error_on_failure: true,
         run_as_job: true,
+        batch_size: 30,
       })
 
       const allCollectionToJobNames = JSON.parse(

--- a/frontend/src/screens/dashboard/docsqa/index.tsx
+++ b/frontend/src/screens/dashboard/docsqa/index.tsx
@@ -1,8 +1,18 @@
+import { MenuItem, Select, TextareaAutosize } from '@mui/material'
+import React, { useEffect, useMemo, useState } from 'react'
+import { SSE } from 'sse.js'
+
 import IconProvider from '@/components/assets/IconProvider'
 import Button from '@/components/base/atoms/Button'
 import Input from '@/components/base/atoms/Input'
 import Markdown from '@/components/base/atoms/Markdown'
 import Spinner from '@/components/base/atoms/Spinner/Spinner'
+import { LightTooltip } from '@/components/base/atoms/Tooltip'
+import Switch from '@/components/base/atoms/Switch'
+import Picker from '@/components/base/atoms/Picker'
+import Modal from '@/components/base/atoms/Modal'
+import notify from '@/components/base/molecules/Notify'
+import SimpleCodeEditor from '@/components/base/molecules/SimpleCodeEditor'
 import {
   CollectionQueryDto,
   SourceDocs,
@@ -13,15 +23,8 @@ import {
   useGetOpenapiSpecsQuery,
   useQueryCollectionMutation,
 } from '@/stores/qafoundry'
-import { MenuItem, Select, Switch, TextareaAutosize } from '@mui/material'
-import React, { useEffect, useMemo, useState } from 'react'
 import NoCollections from './NoCollections'
-import SimpleCodeEditor from '@/components/base/molecules/SimpleCodeEditor'
 import DocsQaInformation from './DocsQaInformation'
-import Modal from '@/components/base/atoms/Modal'
-import notify from '@/components/base/molecules/Notify'
-import { SSE } from 'sse.js'
-import { LightTooltip } from '@/components/base/atoms/Tooltip'
 import SourceDocsPreview from './DocsQA/SourceDocsPreview'
 import { notifyError } from '@/utils/error'
 
@@ -431,29 +434,15 @@ const DocsQA = () => {
               </div>
               <div className="flex justify-between items-center mb-1 mt-3">
                 <div className="text-sm">Model:</div>
-                <Select
-                  value={selectedQueryModel}
-                  onChange={(e) => {
-                    setSelectedQueryModel(e.target.value)
-                  }}
-                  placeholder="Select Model..."
-                  sx={{
-                    background: 'white',
-                    height: '2rem',
-                    width: '13.1875rem',
-                    border: '1px solid #CEE0F8 !important',
-                    outline: 'none !important',
-                    '& fieldset': {
-                      border: 'none !important',
-                    },
-                  }}
-                >
-                  {allEnabledModels?.map((model: any) => (
-                    <MenuItem value={model.name} key={model.name}>
-                      {model.name}
-                    </MenuItem>
-                  ))}
-                </Select>
+                {allEnabledModels &&
+                  <Picker
+                    options={allEnabledModels.map((model: any) => model.name) ?? []}
+                    value={selectedQueryModel}
+                    onChange={(e: any) => {
+                      setSelectedQueryModel(e.target.value as string)
+                    }}
+                  />
+                }
               </div>
               <div className="mb-1 mt-3 text-sm">Model Configuration:</div>
               <SimpleCodeEditor
@@ -506,14 +495,13 @@ const DocsQA = () => {
                   setRetrieverConfig(updatedConfig ?? '')
                 }
               />
-
-              <div className="flex justify-between items-center mt-1.5">
-                <div className="text-sm">Internet Search</div>
+              <label className="label flex justify-between items-center mt-1.5">
+                <span className="label-text text-sm">Internet Search</span>
                 <Switch
                   checked={isInternetSearchEnabled}
-                  onChange={(e) => setIsInternetSearchEnabled(e.target.checked)}
+                  onChange={(checked) => setIsInternetSearchEnabled(checked)}
                 />
-              </div>
+              </label>
               <div className="mb-1 mt-2 text-sm">Prompt Template:</div>
               <TextareaAutosize
                 className="w-full h-20 bg-[#f0f7ff] border border-[#CEE0F8] rounded-lg p-2 text-sm"

--- a/frontend/src/screens/dashboard/docsqa/settings/DataSourcesTable.tsx
+++ b/frontend/src/screens/dashboard/docsqa/settings/DataSourcesTable.tsx
@@ -65,6 +65,7 @@ const DataSourceSyncButton = ({
       data_ingestion_mode: 'INCREMENTAL',
       raise_error_on_failure: true,
       run_as_job: true,
+      batch_size: 30,
     })
     setSkipPolling(false)
     notify(

--- a/frontend/src/stores/constants.ts
+++ b/frontend/src/stores/constants.ts
@@ -7,3 +7,12 @@ export const DOCS_QA_MAX_UPLOAD_SIZE_MB = parseInt(
 )
 export const IS_LOCAL_DEVELOPMENT = import.meta.env.VITE_USE_LOCAL === 'true'
 export const GTAG_ID = import.meta.env.VITE_GTAG_ID
+
+// https://stackoverflow.com/a/58172035/7799568
+export const WEBPAGE_URL_REGEX = "[Hh][Tt][Tt][Pp][Ss]?:\/\/(?:(?:[a-zA-Z\u00a1-\uffff0-9]+-?)*[a-zA-Z\u00a1-\uffff0-9]+)(?:\.(?:[a-zA-Z\u00a1-\uffff0-9]+-?)*[a-zA-Z\u00a1-\uffff0-9]+)*(?:\.(?:[a-zA-Z\u00a1-\uffff]{2,}))(?::\d{2,5})?(?:\/[^\s]*)?"
+
+// DATA SOURCES
+
+export const WEB_SOURCE_NAME = 'web'
+export const LOCAL_SOURCE_NAME = 'localdir'
+export const TFY_SOURCE_NAME = 'truefoundry'

--- a/frontend/src/stores/qafoundry/index.ts
+++ b/frontend/src/stores/qafoundry/index.ts
@@ -340,6 +340,7 @@ export const qafoundryApi = createApi({
         data_ingestion_mode: string
         raise_error_on_failure: boolean
         run_as_job: boolean
+        batch_size?: number
       }) => ({
         url: '/v1/collections/ingest',
         body: payload,

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -191,7 +191,6 @@ const config = {
       })
     }),
     typography,
-    forms,
     lineClamp,
     scrollbar,
     daisyui,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -176,6 +176,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.3.1":
+  version "7.25.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.7.tgz#7ffb53c37a8f247c8c4d335e89cdf16a2e0d0fb6"
+  integrity sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.25.0":
   version "7.25.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.0.tgz#e733dc3134b4fede528c15bc95e89cb98c52592a"
@@ -1373,13 +1380,6 @@
   dependencies:
     "@sentry/types" "8.36.0"
 
-"@tailwindcss/forms@^0.5.9":
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.5.9.tgz#b495c12575d6eae5865b2cbd9876b26d89f16f61"
-  integrity sha512-tM4XVr2+UVTxXJzey9Twx48c1gcxFStqn1pQz0tRsX8o3DvxhN5oY5pvyAbUx7VTaZxpej4Zzvc6h+1RJBzpIg==
-  dependencies:
-    mini-svg-data-uri "^1.2.3"
-
 "@tailwindcss/line-clamp@^0.4.4":
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz#767cf8e5d528a5d90c9740ca66eb079f5e87d423"
@@ -1446,6 +1446,13 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
+
+"@types/hast@^2.0.0":
+  version "2.3.10"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.10.tgz#5c9d9e0b304bbb8879b857225c5ebab2d81d7643"
+  integrity sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==
+  dependencies:
+    "@types/unist" "^2"
 
 "@types/hast@^3.0.0":
   version "3.0.4"
@@ -1566,7 +1573,7 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
   integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
 
-"@types/unist@^2.0.0":
+"@types/unist@^2", "@types/unist@^2.0.0":
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
   integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
@@ -2077,15 +2084,30 @@ character-entities-html4@^2.0.0:
   resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
   integrity sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
 
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
 character-entities-legacy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
   integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
 
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
 character-entities@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
   integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
 character-reference-invalid@^2.0.0:
   version "2.0.1"
@@ -2181,6 +2203,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
+  integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
 comma-separated-tokens@^2.0.0:
   version "2.0.3"
@@ -2494,6 +2521,11 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+entities@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -2951,6 +2983,13 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fault@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
+  integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
+  dependencies:
+    format "^0.2.0"
+
 file-entry-cache@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
@@ -3026,6 +3065,11 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
 
 fraction.js@^4.3.7:
   version "4.3.7"
@@ -3245,6 +3289,51 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-from-parse5@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.1.tgz#654a5676a41211e14ee80d1b1758c399a0327651"
+  integrity sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    devlop "^1.0.0"
+    hastscript "^8.0.0"
+    property-information "^6.0.0"
+    vfile "^6.0.0"
+    vfile-location "^5.0.0"
+    web-namespaces "^2.0.0"
+
+hast-util-parse-selector@^2.0.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
+  integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
+
+hast-util-parse-selector@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-raw@^9.0.0:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-9.0.4.tgz#2da03e37c46eb1a6f1391f02f9b84ae65818f7ed"
+  integrity sha512-LHE65TD2YiNsHD3YuXcKPHXPLuYh/gjp12mOfU8jxSrm1f/yJpsb0F/KKljS6U9LJoP0Ux+tCe8iJ2AsPzTdgA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    hast-util-from-parse5 "^8.0.0"
+    hast-util-to-parse5 "^8.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    parse5 "^7.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.0.tgz#3ed27caf8dc175080117706bf7269404a0aa4f7c"
@@ -3266,12 +3355,57 @@ hast-util-to-jsx-runtime@^2.0.0:
     unist-util-position "^5.0.0"
     vfile-message "^4.0.0"
 
+hast-util-to-parse5@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz#477cd42d278d4f036bc2ea58586130f6f39ee6ed"
+  integrity sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    devlop "^1.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-whitespace@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
   integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
   dependencies:
     "@types/hast" "^3.0.0"
+
+hastscript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-6.0.0.tgz#e8768d7eac56c3fdeac8a92830d58e811e5bf640"
+  integrity sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+
+hastscript@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-8.0.0.tgz#4ef795ec8dee867101b9f23cc830d4baf4fd781a"
+  integrity sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^4.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
+
+highlight.js@^10.4.1, highlight.js@~10.7.0:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
+
+highlightjs-vue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz#fdfe97fbea6354e70ee44e3a955875e114db086d"
+  integrity sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==
 
 history@^5.3.0:
   version "5.3.0"
@@ -3291,6 +3425,11 @@ html-url-attributes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.0.tgz#fc4abf0c3fb437e2329c678b80abb3c62cff6f08"
   integrity sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow==
+
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
 https-proxy-agent@^5.0.0:
   version "5.0.1"
@@ -3362,10 +3501,23 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
 is-alphabetical@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz#01072053ea7c1036df3c7d19a6daaec7f19e789b"
   integrity sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
 
 is-alphanumerical@^2.0.0:
   version "2.0.1"
@@ -3451,6 +3603,11 @@ is-date-object@^1.0.1, is-date-object@^1.0.5:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
+
 is-decimal@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
@@ -3486,6 +3643,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
 is-hexadecimal@^2.0.0:
   version "2.0.1"
@@ -3773,6 +3935,14 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+lowlight@^1.17.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.20.0.tgz#ddb197d33462ad0d93bf19d17b6c301aa3941888"
+  integrity sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==
+  dependencies:
+    fault "^1.0.0"
+    highlight.js "~10.7.0"
 
 lru-cache@^10.2.0:
   version "10.4.3"
@@ -4148,11 +4318,6 @@ mimic-response@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
-mini-svg-data-uri@^1.2.3:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz#8ab0aabcdf8c29ad5693ca595af19dd2ead09939"
-  integrity sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==
-
 minimatch@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.1.tgz#ce0521856b453c86e25f2c4c0d03e6ff7ddc440b"
@@ -4412,6 +4577,18 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-entities@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-4.0.1.tgz#4e2a01111fb1c986549b944af39eeda258fc9e4e"
@@ -4435,6 +4612,13 @@ parse-json@^5.0.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse5@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.2.0.tgz#8a0591ce9b7c5e2027173ab737d4d3fc3d826fab"
+  integrity sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==
+  dependencies:
+    entities "^4.5.0"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -4607,6 +4791,16 @@ prettier@^3.3.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
   integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
+prismjs@^1.27.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
+  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
+prismjs@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
+
 prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
@@ -4615,6 +4809,13 @@ prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+property-information@^5.0.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
+  integrity sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==
+  dependencies:
+    xtend "^4.0.0"
 
 property-information@^6.0.0:
   version "6.5.0"
@@ -4688,6 +4889,11 @@ react-helmet-async@^2.0.5:
     invariant "^2.2.4"
     react-fast-compare "^3.2.2"
     shallowequal "^1.1.0"
+
+react-hook-form@^7.53.0:
+  version "7.53.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.53.0.tgz#3cf70951bf41fa95207b34486203ebefbd3a05ab"
+  integrity sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==
 
 react-icons@^5.2.1:
   version "5.3.0"
@@ -4810,6 +5016,18 @@ react-style-singleton@^2.2.1:
     invariant "^2.2.4"
     tslib "^2.0.0"
 
+react-syntax-highlighter@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.6.1.tgz#fa567cb0a9f96be7bbccf2c13a3c4b5657d9543e"
+  integrity sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "^10.4.1"
+    highlightjs-vue "^1.0.0"
+    lowlight "^1.17.0"
+    prismjs "^1.27.0"
+    refractor "^3.6.0"
+
 react-toastify@^10.0.5:
   version "10.0.5"
   resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-10.0.5.tgz#6b8f8386060c5c856239f3036d1e76874ce3bd1e"
@@ -4885,6 +5103,15 @@ reflect.getprototypeof@^1.0.4:
     globalthis "^1.0.3"
     which-builtin-type "^1.1.3"
 
+refractor@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
+  integrity sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==
+  dependencies:
+    hastscript "^6.0.0"
+    parse-entities "^2.0.0"
+    prismjs "~1.27.0"
+
 regenerator-runtime@^0.14.0:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
@@ -4899,6 +5126,15 @@ regexp.prototype.flags@^1.5.1, regexp.prototype.flags@^1.5.2:
     define-properties "^1.2.1"
     es-errors "^1.3.0"
     set-function-name "^2.0.1"
+
+rehype-raw@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
+  integrity sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-raw "^9.0.0"
+    vfile "^6.0.0"
 
 remark-parse@^11.0.0:
   version "11.0.0"
@@ -5152,6 +5388,11 @@ source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+
+space-separated-tokens@^1.0.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
+  integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
 
 space-separated-tokens@^2.0.0:
   version "2.0.2"
@@ -5704,6 +5945,14 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+vfile-location@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
+  integrity sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile "^6.0.0"
+
 vfile-message@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.2.tgz#c883c9f677c72c166362fd635f21fc165a7d1181"
@@ -5737,6 +5986,11 @@ warning@^4.0.0:
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
+
+web-namespaces@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 web-vitals@^4.2.3:
   version "4.2.3"
@@ -5852,6 +6106,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 yallist@^3.0.2:
   version "3.1.1"

--- a/seccomp.json
+++ b/seccomp.json
@@ -1,0 +1,12 @@
+{
+  "comment": "Allow create user namespaces",
+  "names": [
+    "clone",
+    "setns",
+    "unshare"
+  ],
+  "action": "SCMP_ACT_ALLOW",
+  "args": [],
+  "includes": {},
+  "excludes": {}
+}


### PR DESCRIPTION
# Changelog

- **chore: add crawl4ai**
- **feat: async data loaders implement web crawler**
- **feat: Implement smart web crawler**
- **fix: validate urls for web scraper**
- **fix: remove async scrape logic**
- **chore: include web preview and fix**

# Summary
Refactor's frontend NewDataSource form breaking it into sub components, fixes form validation on required fields. Cleaner state management and separation of abstractions for different flows.
AbstractDataLoader::load_filtered_data is now async this affects all data loaders.
Update web_loader to now use Crawl4Ai to
Fetch sitemap to get a list of URLs to crawl.
Crawl each of the URL using user provided configs (including using model gateway to extract semantic data from the webpage). I wanted to make crawling pages parallel but looks like doing it async cause all urls to timeout. Can revisit this later perhaps with multi-threading.
