### PR TITLE
[HOTFIX] log into truefoundry only when tfy connection is required

### DIFF
--- a/backend/modules/dataloaders/truefoundry_loader.py
+++ b/backend/modules/dataloaders/truefoundry_loader.py
@@ -1,10 +1,12 @@
 import os
 from typing import Dict, Iterator, List
 
+from truefoundry.ml import get_client as get_tfy_client
+
 from backend.logger import logger
 from backend.modules.dataloaders.loader import BaseDataLoader
 from backend.types import DataIngestionMode, DataPoint, DataSource, LoadedDataPoint
-from backend.utils import TRUEFOUNDRY_CLIENT, unzip_file
+from backend.utils import unzip_file
 
 
 class TrueFoundryLoader(BaseDataLoader):
@@ -31,9 +33,11 @@ class TrueFoundryLoader(BaseDataLoader):
 
         # Since only data-dir is allowed, we can directly use the FQN to get the data directory.
         try:
+            # Log into TrueFoundry
+            tfy_client = get_tfy_client()
             # Data source URI contains the Truefoundry FQN(Fully Qualified Name) of the data directory.
             # Use the FQN to get the data directory from TrueFoundry.
-            dataset = TRUEFOUNDRY_CLIENT.get_data_directory_by_fqn(data_source.uri)
+            dataset = tfy_client.get_data_directory_by_fqn(data_source.uri)
             # Download the data directory to the destination directory.
             tfy_files_dir = dataset.download(path=dest_dir)
             logger.debug(f"Data directory download info: {tfy_files_dir}")

--- a/backend/server/routers/internal.py
+++ b/backend/server/routers/internal.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import JSONResponse
 from truefoundry.ml import DataDirectory
+from truefoundry.ml import get_client as get_tfy_client
 from truefoundry.ml.autogen.client.models.signed_url_dto import SignedURLDto
 
 from backend.logger import logger
@@ -14,7 +15,7 @@ from backend.modules.model_gateway.model_gateway import model_gateway
 from backend.server.routers.data_source import add_data_source
 from backend.settings import settings
 from backend.types import CreateDataSource, ModelType, UploadToDataDirectoryDto
-from backend.utils import TRUEFOUNDRY_CLIENT, _get_read_signed_url
+from backend.utils import _get_read_signed_url
 
 router = APIRouter(prefix="/v1/internal", tags=["internal"])
 
@@ -78,8 +79,10 @@ async def upload_to_docker_directory(
 
 @router.post("/upload-to-data-directory")
 async def upload_to_data_directory(req: UploadToDataDirectoryDto):
+    # Log into TrueFoundry
+    tfy_client = get_tfy_client()
     # Create a new data directory.
-    dataset = TRUEFOUNDRY_CLIENT.create_data_directory(
+    dataset = tfy_client.create_data_directory(
         settings.ML_REPO_NAME,
         req.upload_name,
     )

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from typing import Any, Callable, List, Optional, TypeVar, cast
 
 from truefoundry.ml import DataDirectory
-from truefoundry.ml import get_client as get_tfy_client
 from truefoundry.ml.autogen.client.models.signed_url_dto import SignedURLDto
 from typing_extensions import ParamSpec
 
@@ -15,8 +14,6 @@ from backend.logger import logger
 
 P = ParamSpec("P")
 T = TypeVar("T")
-
-TRUEFOUNDRY_CLIENT = get_tfy_client()
 
 
 def flatten(dct, sub_dct_key_name, prefix=None):


### PR DESCRIPTION
- Remove constant `TRUEFOUNDRY_CLIENT` that creates a Truefoundry connection on Bootstrap. 
- Log into Truefoundry only when Truefoundry resources are being accessed. 

Fixes #382