### PR TITLE
fix: frontend changes for error toast, collections 

### DIFF
--- a/frontend/src/screens/dashboard/docsqa/NewCollection.tsx
+++ b/frontend/src/screens/dashboard/docsqa/NewCollection.tsx
@@ -18,7 +18,7 @@ import { notifyError } from '@/utils/error'
 
 interface NewCollectionProps {
   open: boolean
-  onClose: () => void
+  onClose: (collectionName?: string) => void
   onSuccess?: () => void
 }
 
@@ -105,7 +105,7 @@ const NewCollection = ({ open, onClose, onSuccess }: NewCollectionProps) => {
         }),
       )
 
-      onClose()
+      onClose(collectionName)
       resetForm()
       onSuccess?.()
       notify(

--- a/frontend/src/screens/dashboard/docsqa/settings/index.tsx
+++ b/frontend/src/screens/dashboard/docsqa/settings/index.tsx
@@ -182,10 +182,13 @@ const DocsQASettings = () => {
       {newCollectionModalOpen && (
         <NewCollection
           open={newCollectionModalOpen}
-          onClose={() => {
+          onClose={(newCollectionName) => {
             if (searchParams.has('newCollectionOpen')) {
               searchParams.delete('newCollectionOpen')
               setSearchParams(searchParams)
+            }
+            if (newCollectionName) {
+              setSelectedCollection(newCollectionName)
             }
             setNewCollectionModalOpen(false)
           }}

--- a/frontend/src/screens/dashboard/docsqa/settings/index.tsx
+++ b/frontend/src/screens/dashboard/docsqa/settings/index.tsx
@@ -80,6 +80,8 @@ const DocsQASettings = () => {
       ) {
         setSelectedCollection(collectionsNames[0])
       }
+    } else {
+      setSelectedCollection(undefined)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collectionsNames])

--- a/frontend/src/utils/error.ts
+++ b/frontend/src/utils/error.ts
@@ -6,7 +6,7 @@ export function notifyError(baseMessage: string, err?: any, defaultMessage? : st
   err?.message ||
   err?.data?.error ||
     err?.error ||
-    err?.details?.msg || defaultMessage;
+    err?.details?.msg || (typeof err?.data?.detail === 'string' && err?.data?.detail) || defaultMessage;
 
   notify('error', baseMessage, message);
 }


### PR DESCRIPTION
1. Show all errors dynamically whatever comes from API
2. After creating a collection, select that collection automatically
3. After deleting all the collections, the view has to update