### PR TITLE
Add Scalar & Binary Vector Quantization support + frontend UI

### DIFF
--- a/backend/database/schema.prisma
+++ b/backend/database/schema.prisma
@@ -23,6 +23,7 @@ model Collection {
     name                    String  @unique
     description             String?
     embedder_config         Json
+    quantization_config     Json?
     // Collection can have multiple data sources
     associated_data_sources Json    @default("{}")
 

--- a/backend/modules/dataloaders/web_loader.py
+++ b/backend/modules/dataloaders/web_loader.py
@@ -42,9 +42,11 @@ async def extract_urls_from_sitemap(url: str) -> List[Tuple[str, str]]:
     urls = [
         (
             loc.text,
-            loc.find_next_sibling("lastmod").text
-            if loc.find_next_sibling("lastmod")
-            else None,
+            (
+                loc.find_next_sibling("lastmod").text
+                if loc.find_next_sibling("lastmod")
+                else None
+            ),
         )
         for loc in soup.find_all("loc")
     ]

--- a/backend/modules/metadata_store/prisma_store.py
+++ b/backend/modules/metadata_store/prisma_store.py
@@ -69,10 +69,19 @@ class PrismaStore(BaseMetadataStore):
 
     async def acreate_collection(self, collection: CreateCollection) -> Collection:
         logger.info(f"Creating collection: {collection.model_dump()}")
-        collection_data = collection.model_dump()
+        collection_data = collection.model_dump(exclude_unset=True)
         collection_data["embedder_config"] = json.dumps(
             collection_data["embedder_config"]
         )
+        # Handle quantization_config - serialize to JSON if present, remove if None
+        if collection_data.get("quantization_config") is not None:
+            collection_data["quantization_config"] = json.dumps(
+                collection_data["quantization_config"]
+            )
+        elif "quantization_config" in collection_data:
+            # Remove None values to let Prisma handle the optional field
+            collection_data.pop("quantization_config")
+        
         collection: "PrismaCollection" = await self.db.collection.create(
             data=collection_data
         )

--- a/backend/modules/metadata_store/prisma_store.py
+++ b/backend/modules/metadata_store/prisma_store.py
@@ -81,7 +81,7 @@ class PrismaStore(BaseMetadataStore):
         elif "quantization_config" in collection_data:
             # Remove None values to let Prisma handle the optional field
             collection_data.pop("quantization_config")
-        
+
         collection: "PrismaCollection" = await self.db.collection.create(
             data=collection_data
         )
@@ -192,9 +192,9 @@ class PrismaStore(BaseMetadataStore):
                 parser_config=assoc.parser_config,
                 data_source=DataSource.model_validate(data_source.model_dump()),
             )
-            existing_associated_data_sources[
-                assoc.data_source_fqn
-            ] = data_src_to_associate
+            existing_associated_data_sources[assoc.data_source_fqn] = (
+                data_src_to_associate
+            )
 
         # Convert the existing associated data sources to a dictionary
         associated_data_sources = {
@@ -283,9 +283,9 @@ class PrismaStore(BaseMetadataStore):
                 )
 
         # Delete the data source
-        deleted_datasource: Optional[
-            PrismaDataSource
-        ] = await self.db.datasource.delete(where={"fqn": data_source_fqn})
+        deleted_datasource: Optional[PrismaDataSource] = (
+            await self.db.datasource.delete(where={"fqn": data_source_fqn})
+        )
 
         if not deleted_datasource:
             raise HTTPException(
@@ -328,10 +328,10 @@ class PrismaStore(BaseMetadataStore):
     async def aget_data_ingestion_run(
         self, data_ingestion_run_name: str, no_cache: bool = False
     ) -> Optional[DataIngestionRun]:
-        data_ingestion_run: Optional[
-            "PrismaDataIngestionRun"
-        ] = await self.db.ingestionruns.find_first(
-            where={"name": data_ingestion_run_name}
+        data_ingestion_run: Optional["PrismaDataIngestionRun"] = (
+            await self.db.ingestionruns.find_first(
+                where={"name": data_ingestion_run_name}
+            )
         )
         logger.info(f"Data ingestion run: {data_ingestion_run}")
         if data_ingestion_run:
@@ -342,10 +342,10 @@ class PrismaStore(BaseMetadataStore):
         self, collection_name: str, data_source_fqn: str = None
     ) -> List[DataIngestionRun]:
         """Get all data ingestion runs for a collection"""
-        data_ingestion_runs: List[
-            "PrismaDataIngestionRun"
-        ] = await self.db.ingestionruns.find_many(
-            where={"collection_name": collection_name}, order={"id": "desc"}
+        data_ingestion_runs: List["PrismaDataIngestionRun"] = (
+            await self.db.ingestionruns.find_many(
+                where={"collection_name": collection_name}, order={"id": "desc"}
+            )
         )
         return [
             DataIngestionRun.model_validate(data_ir.model_dump())
@@ -356,10 +356,10 @@ class PrismaStore(BaseMetadataStore):
         self, data_ingestion_run_name: str, status: DataIngestionRunStatus
     ) -> DataIngestionRun:
         """Update the status of a data ingestion run"""
-        updated_data_ingestion_run: Optional[
-            "PrismaDataIngestionRun"
-        ] = await self.db.ingestionruns.update(
-            where={"name": data_ingestion_run_name}, data={"status": status}
+        updated_data_ingestion_run: Optional["PrismaDataIngestionRun"] = (
+            await self.db.ingestionruns.update(
+                where={"name": data_ingestion_run_name}, data={"status": status}
+            )
         )
         if not updated_data_ingestion_run:
             raise HTTPException(
@@ -373,11 +373,11 @@ class PrismaStore(BaseMetadataStore):
         self, data_ingestion_run_name: str, errors: Dict[str, Any]
     ) -> None:
         """Log errors for the given data ingestion run"""
-        updated_data_ingestion_run: Optional[
-            "PrismaDataIngestionRun"
-        ] = await self.db.ingestionruns.update(
-            where={"name": data_ingestion_run_name},
-            data={"errors": json.dumps(errors)},
+        updated_data_ingestion_run: Optional["PrismaDataIngestionRun"] = (
+            await self.db.ingestionruns.update(
+                where={"name": data_ingestion_run_name},
+                data={"errors": json.dumps(errors)},
+            )
         )
         if not updated_data_ingestion_run:
             raise HTTPException(
@@ -390,9 +390,9 @@ class PrismaStore(BaseMetadataStore):
     ######
     async def aget_rag_app(self, app_name: str) -> Optional[RagApplication]:
         """Get a RAG application from the metadata store"""
-        rag_app: Optional[
-            "PrismaRagApplication"
-        ] = await self.db.ragapps.find_first_or_raise(where={"name": app_name})
+        rag_app: Optional["PrismaRagApplication"] = (
+            await self.db.ragapps.find_first_or_raise(where={"name": app_name})
+        )
 
         return RagApplication.model_validate(rag_app.model_dump())
 
@@ -412,9 +412,9 @@ class PrismaStore(BaseMetadataStore):
 
     async def adelete_rag_app(self, app_name: str):
         """Delete a RAG application from the metadata store"""
-        deleted_rag_app: Optional[
-            "PrismaRagApplication"
-        ] = await self.db.ragapps.delete(where={"name": app_name})
+        deleted_rag_app: Optional["PrismaRagApplication"] = (
+            await self.db.ragapps.delete(where={"name": app_name})
+        )
         if not deleted_rag_app:
             raise HTTPException(
                 status_code=404,

--- a/backend/modules/vector_db/base.py
+++ b/backend/modules/vector_db/base.py
@@ -19,20 +19,24 @@ class BaseVectorDB(ABC):
         raise NotImplementedError()
 
     def create_collection_with_quantization(
-        self, 
-        collection_name: str, 
+        self,
+        collection_name: str,
         embeddings: Embeddings,
-        quantization_config: Optional[QuantizationConfig] = None
+        quantization_config: Optional[QuantizationConfig] = None,
     ):
         """
         Create a collection with quantization support in the vector database.
         Falls back to regular collection creation if quantization is not supported.
         """
         if quantization_config and self.supports_quantization():
-            return self._create_quantized_collection(collection_name, embeddings, quantization_config)
+            return self._create_quantized_collection(
+                collection_name, embeddings, quantization_config
+            )
         else:
             if quantization_config:
-                logger.warning(f"Quantization not supported by {self.__class__.__name__}, creating regular collection")
+                logger.warning(
+                    f"Quantization not supported by {self.__class__.__name__}, creating regular collection"
+                )
             return self.create_collection(collection_name, embeddings)
 
     def supports_quantization(self) -> bool:
@@ -43,16 +47,18 @@ class BaseVectorDB(ABC):
         return False
 
     def _create_quantized_collection(
-        self, 
-        collection_name: str, 
+        self,
+        collection_name: str,
         embeddings: Embeddings,
-        quantization_config: QuantizationConfig
+        quantization_config: QuantizationConfig,
     ):
         """
         Internal method to create quantized collection.
         Should be implemented by subclasses that support quantization.
         """
-        raise NotImplementedError(f"Quantization not implemented for {self.__class__.__name__}")
+        raise NotImplementedError(
+            f"Quantization not implemented for {self.__class__.__name__}"
+        )
 
     @abstractmethod
     def upsert_documents(

--- a/backend/modules/vector_db/base.py
+++ b/backend/modules/vector_db/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 
 from langchain.docstore.document import Document
 from langchain.embeddings.base import Embeddings
@@ -7,7 +7,7 @@ from langchain.schema.vectorstore import VectorStore
 
 from backend.constants import DEFAULT_BATCH_SIZE_FOR_VECTOR_STORE
 from backend.logger import logger
-from backend.types import DataPointVector
+from backend.types import DataPointVector, QuantizationConfig
 
 
 class BaseVectorDB(ABC):
@@ -17,6 +17,42 @@ class BaseVectorDB(ABC):
         Create a collection in the vector database
         """
         raise NotImplementedError()
+
+    def create_collection_with_quantization(
+        self, 
+        collection_name: str, 
+        embeddings: Embeddings,
+        quantization_config: Optional[QuantizationConfig] = None
+    ):
+        """
+        Create a collection with quantization support in the vector database.
+        Falls back to regular collection creation if quantization is not supported.
+        """
+        if quantization_config and self.supports_quantization():
+            return self._create_quantized_collection(collection_name, embeddings, quantization_config)
+        else:
+            if quantization_config:
+                logger.warning(f"Quantization not supported by {self.__class__.__name__}, creating regular collection")
+            return self.create_collection(collection_name, embeddings)
+
+    def supports_quantization(self) -> bool:
+        """
+        Check if vector DB supports quantization.
+        Default implementation returns False, override in subclasses that support it.
+        """
+        return False
+
+    def _create_quantized_collection(
+        self, 
+        collection_name: str, 
+        embeddings: Embeddings,
+        quantization_config: QuantizationConfig
+    ):
+        """
+        Internal method to create quantized collection.
+        Should be implemented by subclasses that support quantization.
+        """
+        raise NotImplementedError(f"Quantization not implemented for {self.__class__.__name__}")
 
     @abstractmethod
     def upsert_documents(

--- a/backend/modules/vector_db/mongo.py
+++ b/backend/modules/vector_db/mongo.py
@@ -289,9 +289,11 @@ class MongoVectorDB(BaseVectorDB):
         while stop is not True:
             batch_cursor = (
                 collection.find(
-                    {f"metadata.{DATA_POINT_FQN_METADATA_KEY}": base_document_id}
-                    if base_document_id
-                    else {},
+                    (
+                        {f"metadata.{DATA_POINT_FQN_METADATA_KEY}": base_document_id}
+                        if base_document_id
+                        else {}
+                    ),
                     {f"metadata.{DATA_POINT_FQN_METADATA_KEY}": 1},
                 )
                 .skip(offset if offset else 0)

--- a/backend/modules/vector_db/qdrant.py
+++ b/backend/modules/vector_db/qdrant.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from urllib.parse import urlparse
 
 from langchain.embeddings.base import Embeddings
@@ -9,7 +9,7 @@ from qdrant_client.http.models import Distance, VectorParams
 from backend.constants import DATA_POINT_FQN_METADATA_KEY, DATA_POINT_HASH_METADATA_KEY
 from backend.logger import logger
 from backend.modules.vector_db.base import BaseVectorDB
-from backend.types import DataPointVector, QdrantClientConfig, VectorDBConfig
+from backend.types import DataPointVector, QdrantClientConfig, VectorDBConfig, QuantizationConfig, QuantizationType
 
 MAX_SCROLL_LIMIT = int(1e6)
 BATCH_SIZE = 1000
@@ -40,13 +40,15 @@ class QdrantVectorDB(BaseVectorDB):
                 url=url, api_key=api_key, **qdrant_kwargs.model_dump()
             )
 
+    def supports_quantization(self) -> bool:
+        """Qdrant supports quantization"""
+        return True
+
     def create_collection(self, collection_name: str, embeddings: Embeddings):
         logger.debug(f"[Qdrant] Creating new collection {collection_name}")
 
         # Calculate embedding size
-        partial_embeddings = embeddings.embed_documents(["Initial document"])
-        vector_size = len(partial_embeddings[0])
-        logger.debug(f"Vector size: {vector_size}")
+        vector_size = self.get_embedding_dimensions(embeddings)
 
         self.qdrant_client.create_collection(
             collection_name=collection_name,
@@ -63,6 +65,59 @@ class QdrantVectorDB(BaseVectorDB):
             field_schema=models.PayloadSchemaType.KEYWORD,
         )
         logger.debug(f"[Qdrant] Created new collection {collection_name}")
+
+    def _create_quantized_collection(
+        self, 
+        collection_name: str, 
+        embeddings: Embeddings,
+        quantization_config: QuantizationConfig
+    ):
+        logger.debug(f"[Qdrant] Creating quantized collection {collection_name} with {quantization_config.type} quantization")
+
+        # Calculate embedding size
+        vector_size = self.get_embedding_dimensions(embeddings)
+
+        # Configure quantization based on type
+        quantization = None
+        if quantization_config.type == QuantizationType.SCALAR:
+            quantization = models.ScalarQuantization(
+                scalar=models.ScalarQuantizationConfig(
+                    type=models.ScalarType.INT8,
+                    quantile=0.99,
+                    always_ram=quantization_config.always_ram,
+                )
+            )
+            logger.debug(f"[Qdrant] Using scalar quantization (INT8) for collection {collection_name}")
+        elif quantization_config.type == QuantizationType.BINARY:
+            quantization = models.BinaryQuantization(
+                binary=models.BinaryQuantizationConfig(
+                    always_ram=quantization_config.always_ram,
+                )
+            )
+            logger.debug(f"[Qdrant] Using binary quantization for collection {collection_name}")
+        else:
+            logger.warning(f"[Qdrant] Unsupported quantization type: {quantization_config.type}, falling back to no quantization")
+
+        # Create collection with quantization
+        self.qdrant_client.create_collection(
+            collection_name=collection_name,
+            vectors_config=VectorParams(
+                size=vector_size,
+                distance=Distance.COSINE,
+                on_disk=True,
+                quantization_config=quantization,
+            ),
+            replication_factor=3,
+        )
+
+        # Create payload index for metadata
+        self.qdrant_client.create_payload_index(
+            collection_name=collection_name,
+            field_name=f"metadata.{DATA_POINT_FQN_METADATA_KEY}",
+            field_schema=models.PayloadSchemaType.KEYWORD,
+        )
+
+        logger.info(f"[Qdrant] Successfully created quantized collection {collection_name} with {quantization_config.type} quantization")
 
     def _get_records_to_be_upserted(
         self, collection_name: str, data_point_fqns: List[str], incremental: bool

--- a/backend/modules/vector_db/qdrant.py
+++ b/backend/modules/vector_db/qdrant.py
@@ -9,7 +9,13 @@ from qdrant_client.http.models import Distance, VectorParams
 from backend.constants import DATA_POINT_FQN_METADATA_KEY, DATA_POINT_HASH_METADATA_KEY
 from backend.logger import logger
 from backend.modules.vector_db.base import BaseVectorDB
-from backend.types import DataPointVector, QdrantClientConfig, VectorDBConfig, QuantizationConfig, QuantizationType
+from backend.types import (
+    DataPointVector,
+    QdrantClientConfig,
+    VectorDBConfig,
+    QuantizationConfig,
+    QuantizationType,
+)
 
 MAX_SCROLL_LIMIT = int(1e6)
 BATCH_SIZE = 1000
@@ -67,12 +73,14 @@ class QdrantVectorDB(BaseVectorDB):
         logger.debug(f"[Qdrant] Created new collection {collection_name}")
 
     def _create_quantized_collection(
-        self, 
-        collection_name: str, 
+        self,
+        collection_name: str,
         embeddings: Embeddings,
-        quantization_config: QuantizationConfig
+        quantization_config: QuantizationConfig,
     ):
-        logger.debug(f"[Qdrant] Creating quantized collection {collection_name} with {quantization_config.type} quantization")
+        logger.debug(
+            f"[Qdrant] Creating quantized collection {collection_name} with {quantization_config.type} quantization"
+        )
 
         # Calculate embedding size
         vector_size = self.get_embedding_dimensions(embeddings)
@@ -87,16 +95,22 @@ class QdrantVectorDB(BaseVectorDB):
                     always_ram=quantization_config.always_ram,
                 )
             )
-            logger.debug(f"[Qdrant] Using scalar quantization (INT8) for collection {collection_name}")
+            logger.debug(
+                f"[Qdrant] Using scalar quantization (INT8) for collection {collection_name}"
+            )
         elif quantization_config.type == QuantizationType.BINARY:
             quantization = models.BinaryQuantization(
                 binary=models.BinaryQuantizationConfig(
                     always_ram=quantization_config.always_ram,
                 )
             )
-            logger.debug(f"[Qdrant] Using binary quantization for collection {collection_name}")
+            logger.debug(
+                f"[Qdrant] Using binary quantization for collection {collection_name}"
+            )
         else:
-            logger.warning(f"[Qdrant] Unsupported quantization type: {quantization_config.type}, falling back to no quantization")
+            logger.warning(
+                f"[Qdrant] Unsupported quantization type: {quantization_config.type}, falling back to no quantization"
+            )
 
         # Create collection with quantization
         self.qdrant_client.create_collection(
@@ -117,7 +131,9 @@ class QdrantVectorDB(BaseVectorDB):
             field_schema=models.PayloadSchemaType.KEYWORD,
         )
 
-        logger.info(f"[Qdrant] Successfully created quantized collection {collection_name} with {quantization_config.type} quantization")
+        logger.info(
+            f"[Qdrant] Successfully created quantized collection {collection_name} with {quantization_config.type} quantization"
+        )
 
     def _get_records_to_be_upserted(
         self, collection_name: str, data_point_fqns: List[str], incremental: bool

--- a/backend/server/routers/collection.py
+++ b/backend/server/routers/collection.py
@@ -66,15 +66,17 @@ async def create_collection(
         )
     )
     logger.info(f"Creating collection {collection.name} on vector db...")
-    
+
     # Get embeddings model
     embeddings = model_gateway.get_embedder_from_model_config(
         model_name=collection.embedder_config.name
     )
-    
+
     # Create collection with quantization support if specified
     if collection.quantization_config:
-        logger.info(f"Creating collection {collection.name} with {collection.quantization_config.type} quantization...")
+        logger.info(
+            f"Creating collection {collection.name} with {collection.quantization_config.type} quantization..."
+        )
         VECTOR_STORE_CLIENT.create_collection_with_quantization(
             collection_name=collection.name,
             embeddings=embeddings,
@@ -85,7 +87,7 @@ async def create_collection(
             collection_name=collection.name,
             embeddings=embeddings,
         )
-    
+
     logger.info(f"Created collection... {created_collection}")
 
     if collection.associated_data_sources:

--- a/backend/server/routers/collection.py
+++ b/backend/server/routers/collection.py
@@ -62,15 +62,30 @@ async def create_collection(
             name=collection.name,
             description=collection.description,
             embedder_config=collection.embedder_config,
+            quantization_config=collection.quantization_config,
         )
     )
     logger.info(f"Creating collection {collection.name} on vector db...")
-    VECTOR_STORE_CLIENT.create_collection(
-        collection_name=collection.name,
-        embeddings=model_gateway.get_embedder_from_model_config(
-            model_name=collection.embedder_config.name
-        ),
+    
+    # Get embeddings model
+    embeddings = model_gateway.get_embedder_from_model_config(
+        model_name=collection.embedder_config.name
     )
+    
+    # Create collection with quantization support if specified
+    if collection.quantization_config:
+        logger.info(f"Creating collection {collection.name} with {collection.quantization_config.type} quantization...")
+        VECTOR_STORE_CLIENT.create_collection_with_quantization(
+            collection_name=collection.name,
+            embeddings=embeddings,
+            quantization_config=collection.quantization_config,
+        )
+    else:
+        VECTOR_STORE_CLIENT.create_collection(
+            collection_name=collection.name,
+            embeddings=embeddings,
+        )
+    
     logger.info(f"Created collection... {created_collection}")
 
     if collection.associated_data_sources:

--- a/backend/types.py
+++ b/backend/types.py
@@ -118,6 +118,16 @@ class ModelType(str, Enum):
     audio = "audio"
 
 
+class QuantizationType(str, Enum):
+    """
+    Quantization types for embeddings
+    """
+    
+    SCALAR = "scalar"
+    BINARY = "binary"
+    PRODUCT = "product"
+
+
 class ModelConfig(ConfiguredBaseModel):
     name: str
     # TODO (chiragjn): This should not be Optional! Changing might break backward compatibility
@@ -136,6 +146,28 @@ class ModelProviderConfig(ConfiguredBaseModel):
     embedding_model_ids: List[str] = Field(default_factory=list)
     reranking_model_ids: List[str] = Field(default_factory=list)
     audio_model_ids: List[str] = Field(default_factory=list)
+
+
+class QuantizationConfig(ConfiguredBaseModel):
+    """
+    Quantization configuration for embeddings
+    """
+    
+    type: QuantizationType = Field(
+        title="Type of quantization to apply"
+    )
+    rescore: bool = Field(
+        default=True, 
+        title="Enable rescoring with original vectors for better accuracy"
+    )
+    oversampling: Optional[float] = Field(
+        default=None, 
+        title="Oversampling factor for binary quantization"
+    )
+    always_ram: bool = Field(
+        default=True,
+        title="Keep quantized vectors in RAM for faster access"
+    )
 
 
 class EmbedderConfig(ConfiguredBaseModel):
@@ -457,6 +489,15 @@ class BaseCollection(ConfiguredBaseModel):
             "name": "truefoundry/openai-main/text-embedding-3-small",
             "type": "embedding",
         },
+    )
+    quantization_config: Optional[QuantizationConfig] = Field(
+        None,
+        title="Quantization configuration for embeddings to reduce memory usage and improve search speed",
+        example={
+            "type": "scalar",
+            "rescore": True,
+            "always_ram": True
+        }
     )
 
 

--- a/backend/types.py
+++ b/backend/types.py
@@ -122,7 +122,7 @@ class QuantizationType(str, Enum):
     """
     Quantization types for embeddings
     """
-    
+
     SCALAR = "scalar"
     BINARY = "binary"
     PRODUCT = "product"
@@ -152,21 +152,16 @@ class QuantizationConfig(ConfiguredBaseModel):
     """
     Quantization configuration for embeddings
     """
-    
-    type: QuantizationType = Field(
-        title="Type of quantization to apply"
-    )
+
+    type: QuantizationType = Field(title="Type of quantization to apply")
     rescore: bool = Field(
-        default=True, 
-        title="Enable rescoring with original vectors for better accuracy"
+        default=True, title="Enable rescoring with original vectors for better accuracy"
     )
     oversampling: Optional[float] = Field(
-        default=None, 
-        title="Oversampling factor for binary quantization"
+        default=None, title="Oversampling factor for binary quantization"
     )
     always_ram: bool = Field(
-        default=True,
-        title="Keep quantized vectors in RAM for faster access"
+        default=True, title="Keep quantized vectors in RAM for faster access"
     )
 
 
@@ -493,11 +488,7 @@ class BaseCollection(ConfiguredBaseModel):
     quantization_config: Optional[QuantizationConfig] = Field(
         None,
         title="Quantization configuration for embeddings to reduce memory usage and improve search speed",
-        example={
-            "type": "scalar",
-            "rescore": True,
-            "always_ram": True
-        }
+        example={"type": "scalar", "rescore": True, "always_ram": True},
     )
 
 
@@ -529,11 +520,11 @@ class CreateCollectionDto(CreateCollection):
 class UploadToDataDirectoryDto(ConfiguredBaseModel):
     filepaths: List[str]
     # allow only small case alphanumeric and hyphen, should contain at least one alphabet and begin with alphabet
-    upload_name: Annotated[
-        str, StringConstraints(pattern=r"^[a-z][a-z0-9-]*$")
-    ] = Field(  # type:ignore
-        title="Name of the upload",
-        default=str(uuid.uuid4()),
+    upload_name: Annotated[str, StringConstraints(pattern=r"^[a-z][a-z0-9-]*$")] = (
+        Field(  # type:ignore
+            title="Name of the upload",
+            default=str(uuid.uuid4()),
+        )
     )
 
 
@@ -553,10 +544,10 @@ class ListDataIngestionRunsDto(ConfiguredBaseModel):
 
 class RagApplication(ConfiguredBaseModel):
     # allow only small case alphanumeric and hyphen, should contain at least one alphabet and begin with alphabet
-    name: Annotated[
-        str, StringConstraints(pattern=r"^[a-z][a-z0-9-]*$")
-    ] = Field(  # type:ignore
-        title="Name of the rag app",
+    name: Annotated[str, StringConstraints(pattern=r"^[a-z][a-z0-9-]*$")] = (
+        Field(  # type:ignore
+            title="Name of the rag app",
+        )
     )
     config: Dict[str, Any] = Field(
         title="Configuration for the rag app",

--- a/frontend/src/screens/dashboard/docsqa/NewCollection.tsx
+++ b/frontend/src/screens/dashboard/docsqa/NewCollection.tsx
@@ -29,6 +29,7 @@ const NewCollection = ({ open, onClose, onSuccess }: NewCollectionProps) => {
   const [chunkSize, setChunkSize] = React.useState(1000)
   const [selectedDataSource, setSelectedDataSource] = useState('none')
   const [parserConfigs, setParserConfigs] = useState(defaultParserConfigs)
+  const [quantizationType, setQuantizationType] = useState('none')
 
   const { data: dataSources } = useGetDataSourcesQuery()
   const { data: allEmbeddingModels } = useGetAllEnabledEmbeddingModelsQuery()
@@ -52,6 +53,7 @@ const NewCollection = ({ open, onClose, onSuccess }: NewCollectionProps) => {
     }
     setChunkSize(1000)
     setSelectedDataSource('none')
+    setQuantizationType('none')
     setIsSaving(false)
   }
 
@@ -75,6 +77,11 @@ const NewCollection = ({ open, onClose, onSuccess }: NewCollectionProps) => {
         embedder_config: {
           name: embeddingModel.name,
         },
+        ...(quantizationType !== 'none' && {
+          quantization_config: {
+            type: quantizationType,
+          },
+        }),
         associated_data_sources: [
           {
             data_source_fqn: selectedDataSource,
@@ -206,6 +213,45 @@ const NewCollection = ({ open, onClose, onSuccess }: NewCollectionProps) => {
                   </MenuItem>
                 ))}
               </Select>
+            </div>
+          </div>
+          <div className="flex gap-7 w-full mb-4">
+            <div className="w-full">
+              <span className="label-text font-inter mb-1">
+                Vector Quantization <small>(Optional - for memory optimization)</small>
+              </span>
+              <Select
+                id="quantization-type"
+                value={quantizationType}
+                onChange={(e) => {
+                  setQuantizationType(e.target.value)
+                }}
+                placeholder="Select Quantization Type..."
+                sx={{
+                  background: 'white',
+                  height: '2.6rem',
+                  width: '100%',
+                  border: '1px solid #CEE0F8 !important',
+                  outline: 'none !important',
+                  '& fieldset': {
+                    border: 'none !important',
+                  },
+                }}
+              >
+                <MenuItem value="none">No Quantization (Full Precision)</MenuItem>
+                <MenuItem value="scalar">Scalar Quantization (INT8 - 4x smaller)</MenuItem>
+                <MenuItem value="binary">Binary Quantization (1-bit - 32x smaller)</MenuItem>
+              </Select>
+              {quantizationType !== 'none' && (
+                <div className="text-xs text-gray-600 mt-1">
+                  {quantizationType === 'scalar' && (
+                    <span>Reduces memory usage by 4x while maintaining good search quality</span>
+                  )}
+                  {quantizationType === 'binary' && (
+                    <span>Reduces memory usage by 32x with slight quality trade-off</span>
+                  )}
+                </div>
+              )}
             </div>
           </div>
           <div className="mb-3">

--- a/frontend/src/screens/dashboard/docsqa/settings/index.tsx
+++ b/frontend/src/screens/dashboard/docsqa/settings/index.tsx
@@ -150,10 +150,30 @@ const DocsQASettings = () => {
                       collection
                     </div>
                     {collectionDetails && (
-                      <div className="text-sm">
-                        Embedder Used :{' '}
-                        {collectionDetails?.embedder_config?.name}
-                      </div>
+                      <>
+                        <div className="text-sm">
+                          Embedder Used :{' '}
+                          {collectionDetails?.embedder_config?.name}
+                        </div>
+                        {collectionDetails?.quantization_config && (
+                          <div className="text-sm mt-1 flex items-center gap-2">
+                            <span>Quantization :</span>
+                            <span className="capitalize font-medium text-blue-600">
+                              {collectionDetails.quantization_config.type}
+                            </span>
+                            <span className="text-xs bg-green-100 text-green-800 px-2 py-0.5 rounded">
+                              {collectionDetails.quantization_config.type === 'scalar' ? '4x smaller' : 
+                               collectionDetails.quantization_config.type === 'binary' ? '32x smaller' : 
+                               'optimized'}
+                            </span>
+                          </div>
+                        )}
+                        {!collectionDetails?.quantization_config && (
+                          <div className="text-sm mt-1 text-gray-500">
+                            Quantization : None (Full precision)
+                          </div>
+                        )}
+                      </>
                     )}
                   </div>
                   <Button


### PR DESCRIPTION
Closes #436 
Adds backend support to create Qdrant collections with scalar (INT8) and binary quantization.
Exposes a UI control in the New Collection form to choose quantization type (none / scalar / binary).

<img width="1817" height="895" alt="image" src="https://github.com/user-attachments/assets/c00ad4d5-571d-421f-bb32-d5f6b3b03a7a" />
